### PR TITLE
feat(builder): create component builder and increase testing

### DIFF
--- a/modelica_builder/builder.py
+++ b/modelica_builder/builder.py
@@ -1,0 +1,73 @@
+from modelica_builder.selector import ElementListSelector, NthChildSelector
+from modelica_builder.transformation import Transformation
+from modelica_builder.edit import Edit
+
+
+class ComponentBuilder:
+    def __init__(self, insert_index, type_, identifier):
+        """ComponentBuilder allows you to construct and insert a component
+
+        :param insert_index: int, index to place the new component. if < 0, it will insert at the end
+        :param type_: string, type of the component
+        :param identifier: string, component identifier
+        """
+        self._arguments = {}
+        self._annotations = []
+        self._insert_index = insert_index
+        self._type = type_
+        self._identifier = identifier
+
+    def set_argument(self, arg_name, arg_value):
+        """set_argument sets a component initialization argument
+
+        :param arg_name: string, name of the argument
+        :param arg_value: string, value of the argument
+        """
+        self._arguments[arg_name] = arg_value
+
+    def add_annotation(self, annotation):
+        """add_annotation adds an annotation to the component
+
+        :param annotation: string, annotation to add
+        """
+        self._annotations.append(annotation)
+
+    def transformation(self):
+        """transformation creates the transformation required for inserting the
+        built component
+
+        :return: Transformation
+        """
+        if self._insert_index == 0:
+            selector = (ElementListSelector()
+                        .chain(NthChildSelector(0)))
+            insert_after = False
+        if self._insert_index < 0:
+            # insert after the last child
+            selector = (ElementListSelector()
+                        .chain(NthChildSelector(-1)))
+            insert_after = True
+        else:
+            # index is really (insert_index * 2) - 1 because the element_list
+            # is defined as (element ';')* meaning there's a semicolon for every
+            # element to account for.
+            selector = (ElementListSelector()
+                        .chain(NthChildSelector((self._insert_index * 2) - 1)))
+            insert_after = True
+
+        edit = Edit.make_insert(self.build(), insert_after=insert_after)
+        return Transformation(selector, edit)
+
+    def build(self):
+        """build constructs the text for the component
+
+        :return: string
+        """
+        arguments = ''
+        if self._arguments:
+            arguments = f"({', '.join([f'{k}={v}' for k, v in self._arguments.items()])})"
+        annotations = ''
+        if self._annotations:
+            annotations = f"annotation({', '.join(self._annotations)})"
+
+        return f'\n\t{self._type} {self._identifier}{arguments} {annotations};\n\t'

--- a/modelica_builder/edit.py
+++ b/modelica_builder/edit.py
@@ -1,21 +1,14 @@
+from modelica_builder import modelica_parser
+
+
 class Edit:
-    start = None
-    stop = None
-    data = None
+    def __init__(self, start, stop, data):
+        self.start = start
+        self.stop = stop
+        self.data = data
 
     def __lt__(self, other):
         return self.start < other.start
-
-    @staticmethod
-    def _get_span(node):
-        """get the character start and end of a node
-
-        :param node: object, node to get span
-        :return: start, stop, character indices for start and stop of node
-        """
-        # TODO: handle different node types
-        # e.g. if it's a terminal this might not work
-        return node.start.start, node.stop.stop
 
     @classmethod
     def make_delete(cls):
@@ -24,12 +17,8 @@ class Edit:
         :return: function, edit function for delete
         """
         def delete(node):
-            start, stop = cls._get_span(node)
-            edit = cls()
-            edit.start = start
-            edit.stop = stop
-            edit.data = None
-            return edit
+            start, stop = modelica_parser.get_span(node)
+            return cls(start, stop, None)
 
         return delete
 
@@ -41,13 +30,9 @@ class Edit:
         :return: function, edit function for replace
         """
         def replace(node):
-            start, stop = cls._get_span(node)
+            start, stop = modelica_parser.get_span(node)
 
-            edit = cls()
-            edit.start = start
-            edit.stop = stop
-            edit.data = data
-            return edit
+            return cls(start, stop, data)
 
         return replace
 
@@ -60,15 +45,13 @@ class Edit:
         :return: function, edit function for insert
         """
         def insert(node):
-            start, stop = cls._get_span(node)
+            start, stop = modelica_parser.get_span(node)
             if insert_after:
                 start = stop + 1
 
-            edit = cls()
-            edit.start = start
-            edit.stop = stop
-            edit.data = data
-            return edit
+            # set stop to start, we aren't removing any data
+            stop = start
+            return cls(start, stop, data)
 
         return insert
 

--- a/modelica_builder/modelica_parser/__init__.py
+++ b/modelica_builder/modelica_parser/__init__.py
@@ -1,25 +1,10 @@
-from antlr4 import FileStream, CommonTokenStream
-
 from modelica_builder.modelica_parser.modelicaLexer import modelicaLexer
 from modelica_builder.modelica_parser.modelicaParser import modelicaParser
+from modelica_builder.modelica_parser.utils import parse, get_span
 
 __all__ = [
     'modelicaLexer',
     'modelicaParser',
-    'parse'
+    'parse',
+    'get_span'
 ]
-
-
-def parse(source):
-    """parse creates an AST from the given file
-
-    :param source: string, file to parse
-    :return: tree, parser, the tree and parser used to construct the tree
-    """
-    fs = FileStream(source)
-    lexer = modelicaLexer(fs)
-    stream = CommonTokenStream(lexer)
-    parser = modelicaParser(stream)
-    tree = parser.stored_definition()
-
-    return tree, parser

--- a/modelica_builder/modelica_parser/utils.py
+++ b/modelica_builder/modelica_parser/utils.py
@@ -1,0 +1,40 @@
+from antlr4 import FileStream, CommonTokenStream
+from antlr4.tree.Tree import TerminalNodeImpl
+
+from modelica_builder.modelica_parser.modelicaLexer import modelicaLexer
+from modelica_builder.modelica_parser.modelicaParser import modelicaParser
+
+
+def parse(source):
+    """parse creates an AST from the given file
+
+    :param source: string, file to parse
+    :return: tree, parser, the tree and parser used to construct the tree
+    """
+    fs = FileStream(source)
+    lexer = modelicaLexer(fs)
+    stream = CommonTokenStream(lexer)
+    parser = modelicaParser(stream)
+    tree = parser.stored_definition()
+
+    return tree, parser
+
+
+def is_terminal_node(node):
+    return type(node) is TerminalNodeImpl
+
+
+def get_span(node):
+    """get the character start and end of a node
+
+    :param node: object or dict, node to get span
+    :return: start, stop, character indices for start and stop of node
+    """
+    # allow dicts for easy mocking
+    if type(node) is dict:
+        return node['start'], node['stop']
+
+    if is_terminal_node(node):
+        return node.symbol.start, node.symbol.stop
+
+    return node.start.start, node.stop.stop

--- a/modelica_builder/selector.py
+++ b/modelica_builder/selector.py
@@ -223,3 +223,30 @@ class ConnectSelector(Selector):
 
     def _select(self, root, parser):
         return select(root, parser, 'connect_clause')
+
+
+class ElementListSelector(Selector):
+    """ElementListSelector is a selector which returns the element list"""
+
+    def _select(self, root, parser):
+        return select(root, parser, 'element_list')
+
+
+class NthChildSelector(Selector):
+    def __init__(self, n):
+        """NthChildSelector is a selector which returns the nth child
+
+        :param n: int, child's index. If n < 0, it selects the last child
+        """
+        self._idx = n
+
+    def _select(self, root, parser):
+        idx = self._idx
+        if self._idx < 0:
+            # get last child's index
+            idx = root.getChildCount() - 1
+
+        child = root.getChild(idx)
+        if child is None:
+            return []
+        return [child]

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+
+import os
+from unittest import TestCase
+
+from modelica_builder.builder import ComponentBuilder
+from modelica_builder.transformer import Transformer
+
+from .tests import get_diffs
+
+
+class TestComponentBuilder(TestCase):
+    def setUp(self):
+        self.data_dir = os.path.join(os.path.dirname(__file__), 'data')
+        self.output_dir = os.path.join(os.path.dirname(__file__), 'output')
+        if not os.path.exists(self.output_dir):
+            os.makedirs(self.output_dir)
+
+    def test_component_builder_at_index_0(self):
+        # Setup
+        insert_index = 0
+
+        # Act
+        component_builder = ComponentBuilder(insert_index=insert_index, type_='CustomType', identifier='MyComponent')
+        component_builder.set_argument('k', 10)
+        component_builder.add_annotation('Placement(transformation(extent{{10, 16}, {0, 26}}))')
+
+        transformer = Transformer()
+        transformer.add(component_builder.transformation())
+
+        result = transformer.execute(os.path.join(self.data_dir, 'DCMotor.mo'))
+
+        # Assert
+        # write the new file to disk
+        with open(os.path.join(self.output_dir, 'DCMotor_component_builder_0.mo'), 'w') as file:
+            file.write(result)
+
+        with open(os.path.join(self.data_dir, 'DCMotor.mo'), 'r') as f:
+            diffs = get_diffs(f.readlines(), result.splitlines(keepends=True))
+
+            self.assertEqual(1, len(diffs['additions']), f'should have 1 addition, has these: {diffs["additions"]}')
+            self.assertEqual(0, len(diffs['subtractions']), f'should have 0 subtractions, has these: {diffs["subtractions"]}')
+
+            self.assertIn('CustomType MyComponent(k=10) annotation(Placement(transformation(extent{{10, 16}, {0, 26}}))', diffs['additions'][0])
+
+    def test_component_builder_at_index_1(self):
+        # Setup
+        insert_index = 1
+
+        # Act
+        component_builder = ComponentBuilder(insert_index=insert_index, type_='CustomType', identifier='MyComponent')
+        component_builder.set_argument('k', 10)
+        component_builder.add_annotation('Placement(transformation(extent{{10, 16}, {0, 26}}))')
+
+        transformer = Transformer()
+        transformer.add(component_builder.transformation())
+
+        result = transformer.execute(os.path.join(self.data_dir, 'DCMotor.mo'))
+
+        # Assert
+        # write the new file to disk
+        with open(os.path.join(self.output_dir, 'DCMotor_component_builder_1.mo'), 'w') as file:
+            file.write(result)
+
+        with open(os.path.join(self.data_dir, 'DCMotor.mo'), 'r') as f:
+            diffs = get_diffs(f.readlines(), result.splitlines(keepends=True))
+
+            self.assertEqual(1, len(diffs['additions']), f'should have 1 addition, has these: {diffs["additions"]}')
+            self.assertEqual(0, len(diffs['subtractions']), f'should have 0 subtractions, has these: {diffs["subtractions"]}')
+
+            self.assertIn('CustomType MyComponent(k=10) annotation(Placement(transformation(extent{{10, 16}, {0, 26}}))', diffs['additions'][0])
+
+    def test_component_builder_at_end(self):
+        # Setup
+        insert_index = 0
+
+        # Act
+        component_builder = ComponentBuilder(insert_index=insert_index, type_='CustomType', identifier='MyComponent')
+        component_builder.set_argument('k', 10)
+        component_builder.add_annotation('Placement(transformation(extent{{10, 16}, {0, 26}}))')
+
+        transformer = Transformer()
+        transformer.add(component_builder.transformation())
+
+        result = transformer.execute(os.path.join(self.data_dir, 'DCMotor.mo'))
+
+        # Assert
+        # write the new file to disk
+        with open(os.path.join(self.output_dir, 'DCMotor_component_builder_at_end.mo'), 'w') as file:
+            file.write(result)
+
+        with open(os.path.join(self.data_dir, 'DCMotor.mo'), 'r') as f:
+            diffs = get_diffs(f.readlines(), result.splitlines(keepends=True))
+
+            self.assertEqual(1, len(diffs['additions']), f'should have 1 addition, has these: {diffs["additions"]}')
+            self.assertEqual(0, len(diffs['subtractions']), f'should have 0 subtractions, has these: {diffs["subtractions"]}')
+
+            self.assertIn('CustomType MyComponent(k=10) annotation(Placement(transformation(extent{{10, 16}, {0, 26}}))', diffs['additions'][0])

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+from unittest import TestCase
+
+from modelica_builder.edit import Edit
+
+
+class TestEdit(TestCase):
+    def setUp(self):
+        self.data = 'CatBat123'
+
+    def test_make_replace(self):
+        # Setup
+        replace = Edit.make_replace('Dog')
+
+        # Act
+        edit = replace({'start': 0, 'stop': 2})
+        result = Edit.apply_edits([edit], self.data)
+
+        # Assert
+        self.assertEqual('DogBat123', result)
+
+    def test_make_insert_after(self):
+        # Setup
+        insert = Edit.make_insert('Dog', insert_after=True)
+
+        # Act
+        edit = insert({'start': 0, 'stop': 2})
+        result = Edit.apply_edits([edit], self.data)
+
+        # Assert
+        self.assertEqual('CatDogBat123', result)
+
+    def test_make_insert_before(self):
+        # Setup
+        insert = Edit.make_insert('Dog', insert_after=False)
+
+        # Act
+        edit = insert({'start': 0, 'stop': 2})
+        result = Edit.apply_edits([edit], self.data)
+
+        # Assert
+        self.assertEqual('DogCatBat123', result)

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+import os
+from unittest import TestCase
+
+from .tests import ASTAssertions
+
+from modelica_builder.selector import ElementListSelector, NthChildSelector
+from modelica_builder.modelica_parser import parse
+
+
+class TestSelectors(TestCase, ASTAssertions):
+    def setUp(self):
+        self.data_dir = os.path.join(os.path.dirname(__file__), 'data')
+        self.output_dir = os.path.join(os.path.dirname(__file__), 'output')
+        if not os.path.exists(self.output_dir):
+            os.makedirs(self.output_dir)
+
+    def test_element_list_selector(self):
+        # Setup
+        tree, parser = parse(os.path.join(self.data_dir, 'DCMotor.mo'))
+
+        # Act
+        selector = ElementListSelector()
+        element_list = selector.apply(tree, parser)
+
+        # Assert
+        self.assertEqual(1, len(element_list), "should have one element list")
+        self.assertIsRule(element_list[0], 'element_list', parser)
+
+    def test_nth_child_selector(self):
+        # Setup
+        tree, parser = parse(os.path.join(self.data_dir, 'DCMotor.mo'))
+
+        # Act
+        selector = (ElementListSelector()
+                    .chain(NthChildSelector(2)))
+        element = selector.apply(tree, parser)
+
+        # Assert
+        self.assertEqual(1, len(element), "should have one element")
+        # the third child should be the Inductor line
+        # (semicolons are also children of the element_list)
+        elementText = element[0].getText()
+        self.assertTrue(elementText.startswith('Inductor'))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,0 +1,26 @@
+import difflib
+
+
+class ASTAssertions:
+    def assertIsRule(self, element, expected_rule, parser):
+        element_rule = parser.ruleNames[element.getRuleIndex()]
+        if element_rule != expected_rule:
+            raise AssertionError(f'Element does not match expected rule. Expected {expected_rule} but was {element_rule}')
+
+
+def ignore_diff(line):
+    return len(clean_diff(line).strip()) == 0
+
+
+def clean_diff(line):
+    return line[1:]
+
+
+def get_diffs(original, new):
+    differ = difflib.Differ()
+    diffs = list(differ.compare(original, new))
+
+    return {
+        'additions': [clean_diff(d) for d in diffs if d.startswith('+') and not ignore_diff(d)],
+        'subtractions': [clean_diff(d) for d in diffs if d.startswith('-') and not ignore_diff(d)]
+    }


### PR DESCRIPTION
## Additions
- implements a component builder. I guess this is the style of class is how we should implement builders (have build() and transformation() methods)
- add an NthChildSelector and ElementListSelector
- tests for some selectors and edits
- test helpers for making assertions about AST and file diffs

## Changes
- refactor Edit class

## Things to note
- builder is space ignorant, and just inserts it one tab indented. If we care about consistent indentation, we should consider refactoring the Edit to handle structured data which could indicate "separable lines" and can detect indentation around it if we're inserting a new line

- If a user builds a component, they'll need to make sure the class type is already imported as well. Might want to add a method for this, or include it in the component builder