### PR TITLE
Fix/replace delete conflicts

### DIFF
--- a/modelica_builder/edit.py
+++ b/modelica_builder/edit.py
@@ -10,13 +10,27 @@ from modelica_builder import modelica_parser
 
 
 class Edit:
-    def __init__(self, start, stop, data):
+    DELETE = 'delete'
+    REPLACE = 'replace'
+    INSERT = 'insert'
+
+    def __init__(self, start, stop, data, operation):
         self.start = start
         self.stop = stop
         self.data = data
+        self._operation = operation
 
     def __lt__(self, other):
-        return self.start < other.start
+        """Sort by start then by stop"""
+        if self.start != other.start:
+            return self.start < other.start
+
+        return self.stop <= other.stop
+
+    def __repr__(self):
+        attributes = [f'{attr}={repr(getattr(self, attr))}'
+                      for attr in self.__dict__.keys() if not attr.startswith('__')]
+        return f'Edit({", ".join(attributes)})'
 
     @classmethod
     def make_delete(cls):
@@ -26,7 +40,7 @@ class Edit:
         """
         def delete(node):
             start, stop = modelica_parser.get_span(node)
-            return cls(start, stop, None)
+            return cls(start, stop, None, cls.DELETE)
 
         return delete
 
@@ -40,7 +54,7 @@ class Edit:
         def replace(node):
             start, stop = modelica_parser.get_span(node)
 
-            return cls(start, stop, data)
+            return cls(start, stop, data, cls.REPLACE)
 
         return replace
 
@@ -59,22 +73,25 @@ class Edit:
 
             # set stop to start, we aren't removing any data
             stop = start
-            return cls(start, stop, data)
+            return cls(start, stop, data, cls.INSERT)
 
         return insert
 
-    @staticmethod
-    def apply_edits(edits, document):
-        """Apply the list of edits in order to the document
+    @classmethod
+    def apply_edits(cls, edits, document):
+        """Sort, fix, and apply the edits to the document
+
+        Raises an exception if it's unable to resolve overlapping edits
 
         :param edits: list, collection of edits to be applied
         :param document: string, document to apply edits to
         :return: string, edited document
         """
+        ordered_edits = cls._sort_and_fix_edits(edits)
         # very inefficient- strings are immutable in Python so we are copying
         # entire document for every edit
         # O(m*n), m = bytes in document, n = number of edits
-        for edit in edits:
+        for edit in ordered_edits:
             # remove edit span
             if edit.start != edit.stop:
                 document = document[:edit.start] + document[edit.stop + 1:]
@@ -86,3 +103,84 @@ class Edit:
                     document[edit.start:]
 
         return document
+
+    @classmethod
+    def _sort_and_fix_edits(cls, edits):
+        """Sorts edits and tries to remove any overlaps as best as possible
+        The result can then be applied in order to data
+
+        :param edits: list, list of edits to sort and fix
+        :return: list, edits in sorted order for application
+        """
+        if not edits:
+            return []
+
+        edits.sort()
+        fixed_edits = [edits[0]]
+        # fix edits by removing or merging overlapping edits
+        for current_edit in edits[1:]:
+            last_edit = fixed_edits[-1]
+            # if non-overlapping, keep both edits
+            non_overlapping = last_edit.start < current_edit.start and last_edit.stop <= current_edit.stop
+            if non_overlapping:
+                fixed_edits.append(current_edit)
+                continue
+
+            # if edits have equal spans, priority is based on operation type
+            if current_edit.start == last_edit.start and current_edit.stop == last_edit.stop:
+                # arbitrarily choose last_edit if the operations are the same
+                if current_edit._operation == last_edit._operation:
+                    continue
+
+                operations = [
+                    current_edit._operation,
+                    last_edit._operation
+                ]
+                # if one is a delete it's retained and the other is dropped
+                if cls.DELETE in operations:
+                    if current_edit._operation == cls.DELETE:
+                        fixed_edits.pop()
+                        fixed_edits.append(current_edit)
+                    continue
+                # if one is a replace it's retained and the other is dropped
+                if cls.REPLACE in operations:
+                    if current_edit._operation == cls.REPLACE:
+                        fixed_edits.pop()
+                        fixed_edits.append(current_edit)
+                    continue
+                # by process of elimination we should have handled all cases by now
+                raise Exception(f'Unexpected case comparing edits:\n  Last Edit: {last_edit}\n  Current Edit: {current_edit}')
+
+            # handle cases where one edit 'consumes' the other
+            #
+            # CASE 1 - last edit consumes current edit (discard current edit)
+            # [.....]
+            #   [..]
+            #
+            # CASE 2 - current edit consumes last edit (discard last edit and keep current edit)
+            # [..]
+            # [.....]
+            #
+            # CASE 3 - last edit is an INSERT (keep both edits)
+            # []
+            # [....]
+            # Case 1
+            if last_edit.start <= current_edit.start and current_edit.stop <= last_edit.stop:
+                continue
+            # Case 2 or 3
+            if current_edit.start == last_edit.start and last_edit.stop <= current_edit.stop:
+                # Case 3
+                if last_edit._operation == cls.INSERT:
+                    fixed_edits.append(current_edit)
+                    continue
+                # Case 2
+                fixed_edits.pop()
+                fixed_edits.append(current_edit)
+                continue
+
+            # raise an exception if we reach this point as we aren't sure how to handle it yet
+            raise Exception(f'Unhandled case for fixing edits:\n  Last Edit: {last_edit}\n  Current Edit: {current_edit}')
+
+        # reverse the result so the edits towards the end of the document are applied first
+        # this prevents clobbering the indices
+        return reversed(fixed_edits)

--- a/modelica_builder/edit.py
+++ b/modelica_builder/edit.py
@@ -128,9 +128,15 @@ class Edit:
 
             # if edits have equal spans, priority is based on operation type
             if current_edit.start == last_edit.start and current_edit.stop == last_edit.stop:
-                # arbitrarily choose last_edit if the operations are the same
+                # check if operations are the same
                 if current_edit._operation == last_edit._operation:
-                    continue
+                    # if both are inserts, keep both edits
+                    if current_edit._operation == cls.INSERT:
+                        fixed_edits.append(current_edit)
+                        continue
+                    # else arbitrarily choose the last_edit by dropping the current
+                    else:
+                        continue
 
                 operations = [
                     current_edit._operation,

--- a/modelica_builder/transformer.py
+++ b/modelica_builder/transformer.py
@@ -113,9 +113,6 @@ class Transformer:
                 selected_nodes = self.apply_selector(transformation.selector)
                 all_edits += [transformation.edit(node) for node in selected_nodes]
 
-        # sort the edits
-        all_edits.sort()
+        # apply the edits
         with open(self._source, 'r') as f:
-            return Edit.apply_edits(
-                reversed(all_edits),
-                f.read())
+            return Edit.apply_edits(all_edits, f.read())

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -266,3 +266,20 @@ class TestModel(TestCase, DiffAssertions):
         # Assert
         self.assertHasAdditions(source_file, self.result, ['parameter String myParam="supercalifragilisticexpialidocious" "a comment"'])
         self.assertNoDeletions(source_file, self.result)
+
+    def test_model_remove_first_component_and_add_param(self):
+        """Tests that we can successfully resolve overlapping edits of a deletion
+        (removing first component) and an insert (adding new param)
+        """
+        # Setup
+        source_file = os.path.join(self.data_dir, 'DCMotor.mo')
+        model = Model(source_file)
+
+        # Act
+        model.remove_component('Resistor', 'R')
+        model.add_parameter('Real', 'myParam', string_comment='a comment', assigned_value='10.0')
+        self.result = model.execute()
+
+        # Assert
+        self.assertHasAdditions(source_file, self.result, ['parameter Real myParam=10.0 "a comment"'])
+        self.assertHasDeletions(source_file, self.result, ['Resistor R(R=100);'])

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -176,6 +176,26 @@ class TestModel(TestCase, DiffAssertions):
         self.assertHasAdditions(source_file, self.result, ['FancyClass myInstance(arg1=1234) "my comment" annotation(my annotation);'])
         self.assertNoDeletions(source_file, self.result)
 
+    def test_model_insert_component_multiple(self):
+        # Setup
+        source_file = os.path.join(self.data_dir, 'DCMotor.mo')
+        model = Model(source_file)
+
+        # Act
+        model.insert_component('FancyClass', 'myInstance',
+                               arguments={'arg1': '1234'}, string_comment='my comment',
+                               annotations=['my annotation'])
+        model.insert_component('AnotherClass', 'anotherInstance',
+                               arguments={'x': '"hello"'}, string_comment='this is another class',
+                               annotations=['abc'])
+        self.result = model.execute()
+
+        # Assert
+        self.assertHasAdditions(source_file, self.result, [
+            'FancyClass myInstance(arg1=1234) "my comment" annotation(my annotation);',
+            'AnotherClass anotherInstance(x="hello") "this is another class" annotation(abc);'])
+        self.assertNoDeletions(source_file, self.result)
+
     def test_model_remove_component(self):
         # Setup
         source_file = os.path.join(self.data_dir, 'DCMotor.mo')


### PR DESCRIPTION
## Fixes
- refactor Edits to have a method which sorts and fixes Edits, handling some cases where edit positions overlap. Previously, there was an issue if an insert and delete happened at the same starting position. The replacement might be applied before the deletion, resulting in the deletion occurring on the replacement text.