### PR TITLE
Conditional Component and Falsy Bug

### DIFF
--- a/modelica_builder/builder.py
+++ b/modelica_builder/builder.py
@@ -25,6 +25,7 @@ class ComponentBuilder:
         """
         self._arguments = {}
         self._annotations = []
+        self._conditional = None
         self._string_comment = None
         self._insert_index = insert_index
         self._type = type_
@@ -37,6 +38,9 @@ class ComponentBuilder:
         :param arg_value: string, value of the argument
         """
         self._arguments[arg_name] = arg_value
+
+    def set_conditional(self, conditional):
+        self._conditional = conditional
 
     def set_string_comment(self, string_comment):
         self._string_comment = string_comment
@@ -80,6 +84,10 @@ class ComponentBuilder:
         if self._arguments:
             arguments = f"({', '.join([f'{k}={v}' for k, v in self._arguments.items()])})"
 
+        conditional = ''
+        if self._conditional:
+            conditional = f" {self._conditional}"
+
         string_comment = ''
         if self._string_comment:
             string_comment = f' "{self._string_comment}"'
@@ -88,7 +96,7 @@ class ComponentBuilder:
         if self._annotations:
             annotations = f" annotation({', '.join(self._annotations)})"
 
-        return f'\n\t{self._type} {self._identifier}{arguments}{string_comment}{annotations};\n\t'
+        return f'\n\t{self._type} {self._identifier}{arguments}{conditional}{string_comment}{annotations};\n\t'
 
 
 class ConnectBuilder:
@@ -205,7 +213,7 @@ class ParameterBuilder:
             arguments = f"({', '.join([f'{k}={v}' for k, v in self._arguments.items()])})"
 
         value_assignment = ''
-        if self._value:
+        if self._value is not None:
             value_assignment = f"={self._value}"
 
         string_comment = ''

--- a/modelica_builder/model.py
+++ b/modelica_builder/model.py
@@ -20,7 +20,10 @@ from modelica_builder.selector import (
     ParentSelector,
     WithinSelector
 )
-from modelica_builder.transformation import SimpleTransformation, ModelAnnotationTransformation
+from modelica_builder.transformation import (
+    ModelAnnotationTransformation,
+    SimpleTransformation
+)
 from modelica_builder.transformer import Transformer
 
 
@@ -110,12 +113,13 @@ class Model(Transformer):
                         .chain(NthChildSelector(4)))
             self.add(SimpleTransformation(selector, Edit.make_replace(new_port_b)))
 
-    def insert_component(self, type_, identifier, arguments=None, string_comment=None, annotations=None, insert_index=-1):
+    def insert_component(self, type_, identifier, arguments=None, conditional=None, string_comment=None, annotations=None, insert_index=-1):
         """insert_component constructs and inserts a component
 
         :param type_: string, type of the component
         :param identifier: string, component identifier
         :param arguments: dict {string: string}, component initialization arguments with arg name as the key and arg value as the value
+        :param conditional: string, conditional applied to the modelica component
         :param string_comment: string
         :param annotations: list of strings, annotations to add to the component
         :param insert_index: int, index to place the new component. if < 0, it will insert at the end
@@ -124,6 +128,9 @@ class Model(Transformer):
         if arguments is not None:
             for arg_name, arg_value in arguments.items():
                 component.set_argument(arg_name, arg_value)
+
+        if conditional is not None:
+            component.set_conditional(conditional)
 
         if string_comment is not None:
             component.set_string_comment(string_comment)
@@ -192,7 +199,8 @@ class Model(Transformer):
             for annotation in annotations:
                 parameter.add_annotation(annotation)
 
-        if assigned_value:
+        # Make sure that 0 is an allowed value (i.e., check for not None instead of truthy)
+        if assigned_value is not None:
             parameter.set_value(assigned_value)
 
         self.add(parameter.transformation())


### PR DESCRIPTION
Needed to allow this format:

```
Modelica.Blocks.Sources.RealExpression perLatLoa(y=internalGains.y[2]*fraLat) if use_moisture_balance 
"Latent person loads"
annotation(Placement(transformation(extent={{-80,-60},{-60,-40}})));
```

There was also a couple of places where None and 0 were being seen as False. Which was not the case.




