### PR TITLE
feat(model): add update_component_modifications method

### DIFF
--- a/modelica_builder/builder.py
+++ b/modelica_builder/builder.py
@@ -23,7 +23,7 @@ class ComponentBuilder:
         :param type_: string, type of the component
         :param identifier: string, component identifier
         """
-        self._arguments = {}
+        self._modifications = {}
         self._annotations = []
         self._conditional = None
         self._string_comment = None
@@ -31,13 +31,13 @@ class ComponentBuilder:
         self._type = type_
         self._identifier = identifier
 
-    def set_argument(self, arg_name, arg_value):
-        """set_argument sets a component initialization argument
+    def set_modification(self, arg_name, arg_value):
+        """set_modification sets a component initialization modification
 
-        :param arg_name: string, name of the argument
-        :param arg_value: string, value of the argument
+        :param arg_name: string, name of the modification
+        :param arg_value: string, value of the modification
         """
-        self._arguments[arg_name] = arg_value
+        self._modifications[arg_name] = arg_value
 
     def set_conditional(self, conditional):
         self._conditional = conditional
@@ -80,9 +80,9 @@ class ComponentBuilder:
 
         :return: string
         """
-        arguments = ''
-        if self._arguments:
-            arguments = f"({', '.join([f'{k}={v}' for k, v in self._arguments.items()])})"
+        modifications = ''
+        if self._modifications:
+            modifications = f"({', '.join([f'{k}={v}' for k, v in self._modifications.items()])})"
 
         conditional = ''
         if self._conditional:
@@ -96,7 +96,7 @@ class ComponentBuilder:
         if self._annotations:
             annotations = f" annotation({', '.join(self._annotations)})"
 
-        return f'\n\t{self._type} {self._identifier}{arguments}{conditional}{string_comment}{annotations};\n\t'
+        return f'\n\t{self._type} {self._identifier}{modifications}{conditional}{string_comment}{annotations};\n\t'
 
 
 class ConnectBuilder:
@@ -144,7 +144,7 @@ class ParameterBuilder:
         :param type_: string, type of the parameter
         :param identifier: string, parameter identifier
         """
-        self._arguments = {}
+        self._modifications = {}
         self._value = None
         self._annotations = []
         self._string_comment = None
@@ -152,13 +152,13 @@ class ParameterBuilder:
         self._type = type_
         self._identifier = identifier
 
-    def set_argument(self, arg_name, arg_value):
-        """set_argument sets a parameter initialization argument
+    def set_modification(self, arg_name, arg_value):
+        """set_modification sets a parameter initialization modification
 
-        :param arg_name: string, name of the argument
-        :param arg_value: string, value of the argument
+        :param arg_name: string, name of the modification
+        :param arg_value: string, value of the modification
         """
-        self._arguments[arg_name] = arg_value
+        self._modifications[arg_name] = arg_value
 
     def set_value(self, value):
         """set_value sets the value of the parameter
@@ -208,9 +208,9 @@ class ParameterBuilder:
 
         :return: string
         """
-        arguments = ''
-        if self._arguments:
-            arguments = f"({', '.join([f'{k}={v}' for k, v in self._arguments.items()])})"
+        modifications = ''
+        if self._modifications:
+            modifications = f"({', '.join([f'{k}={v}' for k, v in self._modifications.items()])})"
 
         value_assignment = ''
         if self._value is not None:
@@ -224,4 +224,4 @@ class ParameterBuilder:
         if self._annotations:
             annotations = f" annotation({', '.join(self._annotations)})"
 
-        return f'\n\tparameter {self._type} {self._identifier}{arguments}{value_assignment}{string_comment}{annotations};\n\t'
+        return f'\n\tparameter {self._type} {self._identifier}{modifications}{value_assignment}{string_comment}{annotations};\n\t'

--- a/modelica_builder/model.py
+++ b/modelica_builder/model.py
@@ -12,8 +12,8 @@ import os
 from modelica_builder.builder import ComponentBuilder, ConnectBuilder, ParameterBuilder
 from modelica_builder.edit import Edit
 from modelica_builder.selector import (
-    ComponentArgumentValueSelector,
     ComponentDeclarationSelector,
+    ComponentModificationValueSelector,
     ConnectClauseSelector,
     ModelIdentifierSelector,
     NthChildSelector,
@@ -26,7 +26,6 @@ from modelica_builder.transformation import (
     SimpleTransformation
 )
 from modelica_builder.transformer import Transformer
-
 
 logger = logging.getLogger(__name__)
 
@@ -164,19 +163,21 @@ class Model(Transformer):
 
         self.add(SimpleTransformation(selector, Edit.make_delete()))
 
-    def update_component_argument(self, type_, identifier, argument_name, new_value, if_value=None):
-        """update_component_argument changes the value of an _existing_ component
-        initialization argument value. ie this won't work if the argument isn't
-        already used
+    def update_component_modification(self, type_, identifier, modification_name, new_value, if_value=None):
+        """update_component_modification changes the value of an _existing_ component
+        modification value. ie this won't work if the argument isn't already used
 
         :param type_: string, component type
         :param identifier: string, component identifier
-        :param argument_name: string, argument to update
-        :param new_value: string, new argument value
+        :param modification_name: string, modification to update
+        :param new_value: string, new modification value
         :param if_value: string, if provided it will only update the value if the existing value matches this
         """
         selector = (ComponentDeclarationSelector(type_, identifier)
-                    .chain(ComponentArgumentValueSelector(argument_name, argument_value=if_value)))
+                    .chain(
+                        ComponentModificationValueSelector(
+                            modification_name,
+                            modification_value=if_value)))
 
         self.add(SimpleTransformation(selector, Edit.make_replace(new_value)))
 

--- a/modelica_builder/model.py
+++ b/modelica_builder/model.py
@@ -116,21 +116,21 @@ class Model(Transformer):
                         .chain(NthChildSelector(4)))
             self.add(SimpleTransformation(selector, Edit.make_replace(new_port_b)))
 
-    def insert_component(self, type_, identifier, arguments=None, conditional=None, string_comment=None, annotations=None, insert_index=-1):
+    def insert_component(self, type_, identifier, modifications=None, conditional=None, string_comment=None, annotations=None, insert_index=-1):
         """insert_component constructs and inserts a component
 
         :param type_: string, type of the component
         :param identifier: string, component identifier
-        :param arguments: dict {string: string}, component initialization arguments with arg name as the key and arg value as the value
+        :param modifications: dict {string: string}, component initialization modifications with arg name as the key and arg value as the value
         :param conditional: string, conditional applied to the modelica component
         :param string_comment: string
         :param annotations: list of strings, annotations to add to the component
         :param insert_index: int, index to place the new component. if < 0, it will insert at the end
         """
         component = ComponentBuilder(insert_index, type_, identifier)
-        if arguments is not None:
-            for arg_name, arg_value in arguments.items():
-                component.set_argument(arg_name, arg_value)
+        if modifications is not None:
+            for arg_name, arg_value in modifications.items():
+                component.set_modification(arg_name, arg_value)
 
         if conditional is not None:
             component.set_conditional(conditional)
@@ -200,21 +200,21 @@ class Model(Transformer):
         """
         self.add(ComponentModificationsTransformation(type_, identifier, modifications))
 
-    def add_parameter(self, type_, identifier, arguments=None, assigned_value=None, string_comment=None, annotations=None):
+    def add_parameter(self, type_, identifier, modifications=None, assigned_value=None, string_comment=None, annotations=None):
         """add_parameter inserts a new parameter at the top of the model's element list
 
         :param type_: string, type of the component
         :param identifier: string, component identifier
-        :param arguments: dict {string: variant}, component initialization arguments with arg name as the key and arg value as the value
+        :param modifications: dict {string: variant}, component initialization modifications with arg name as the key and arg value as the value
         :param assigned_value: variant, value to assign to the parameter
         :param string_comment: string, comment to add
         :param annotations: list of strings, annotations to add to the component
         """
         parameter = ParameterBuilder(0, type_, identifier)
 
-        if arguments:
-            for arg_name, arg_value in arguments.items():
-                parameter.set_argument(arg_name, arg_value)
+        if modifications:
+            for arg_name, arg_value in modifications.items():
+                parameter.set_modification(arg_name, arg_value)
 
         if string_comment:
             parameter.set_string_comment(string_comment)

--- a/modelica_builder/selector.py
+++ b/modelica_builder/selector.py
@@ -158,15 +158,20 @@ class ComponentDeclarationSelector(Selector):
             if node.declaration().IDENT().getText() == self._identifier]
 
 
-class ComponentArgumentValueSelector(Selector):
-    """ComponentArgumentSelector returns arguments to component
+class ComponentModificationValueSelector(Selector):
+    """ComponentModificationSelector returns modifications to component
     declarations
     """
     BASE_PATH = 'stored_definition/class_definition/class_specifier/long_class_specifier/composition/element_list/element/component_clause/component_list/component_declaration'
 
-    def __init__(self, argument_name, argument_value=None):
-        self._argument_name = argument_name
-        self._argument_value = argument_value
+    def __init__(self, modification_name, modification_value=None):
+        """
+        :param modification_name: str, mane of the modification to select
+        :param modification_value: None | str, if not None, it only selects modifications with this value
+        """
+
+        self._modification_name = modification_name
+        self._modification_value = modification_value
         super().__init__()
 
     def _select(self, base, parser):
@@ -176,8 +181,8 @@ class ComponentArgumentValueSelector(Selector):
         # filter modifications (ie arguments) to those that match our name
         filtered_modifications = []
         for element_modification in element_modifications:
-            argument_name_text = element_modification.name().getText()
-            if argument_name_text == self._argument_name:
+            modification_name_text = element_modification.name().getText()
+            if modification_name_text == self._modification_name:
                 filtered_modifications.append(element_modification)
 
         # get the argument expressions (ie argument values)
@@ -186,12 +191,12 @@ class ComponentArgumentValueSelector(Selector):
             xpath = '//expression'
             results.extend(XPath.XPath.findAll(element_modification, xpath, parser))
 
-        # filter out non-matching values if argument_value is specified
-        if self._argument_value is not None:
+        # filter out non-matching values if modification_value is specified
+        if self._modification_value is not None:
             filtered_results = []
             for result in results:
                 a = result.getText()
-                b = self._argument_value
+                b = self._modification_value
                 if re.sub(r"\s*", "", a) == re.sub(r"\s*", "", b):
                     filtered_results.append(result)
             results = filtered_results

--- a/modelica_builder/transformation.py
+++ b/modelica_builder/transformation.py
@@ -7,14 +7,19 @@ All rights reserved.
 
 
 from copy import deepcopy
+import logging
 
 from antlr4.xpath import XPath
 
 from modelica_builder.edit import Edit
 from modelica_builder.selector import (
+    ComponentDeclarationSelector,
     EquationSectionSelector,
     NthChildSelector,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 class SimpleTransformation:
@@ -27,23 +32,70 @@ class SimpleTransformation:
         return [self.edit(node) for node in selected_nodes]
 
 
+def build_modifications(modifications):
+    """returns a string with modifications formatted properly"""
+    mod_strings = []
+    for mod_name, mod_value in modifications.items():
+        if isinstance(mod_value, dict):
+            # treat the modification as a class_modification
+            mod_strings.append(f'{mod_name}({build_modifications(mod_value)})')
+        else:
+            # treat the modification as a simple assignment
+            mod_strings.append(f'{mod_name}={mod_value}')
+    return ', '.join(mod_strings)
+
+
+def make_edits_for_modifications(class_modification_node, modifications, parser):
+    """Constructs a list of edits required to update the node with the
+    provided modifications.
+
+    :param class_modification_node: modelicaParser.Class_modificationContext
+    :param modifications: dict
+    """
+    requested_modifications = deepcopy(modifications)
+    overwrite_modifications = requested_modifications.pop('OVERWRITE_MODIFICATIONS', False)
+    if overwrite_modifications:
+        # don't care about selectively updating existing values
+        # just overwrite any existing modifications
+        new_modifications_string = build_modifications(requested_modifications)
+        edit = Edit.make_replace(new_modifications_string)
+        # replace the entire argument_list with our new modifications
+        return [edit(class_modification_node.argument_list())]
+
+    all_edits = []
+    element_modification_xpath = 'class_modification/argument_list/argument/element_modification_or_replaceable/element_modification'
+    element_modification_nodes = XPath.XPath.findAll(class_modification_node, element_modification_xpath, parser)
+
+    # iterate through the existing element modifications
+    for element_modification_node in element_modification_nodes:
+        # check if there's a request to update this modification
+        element_modification_name = element_modification_node.name().getText()
+        if element_modification_name in requested_modifications:
+            # found a modification to update
+            requested_modification_value = requested_modifications.pop(element_modification_name)
+            if isinstance(requested_modification_value, dict):
+                # recursively make edits for this modification
+                next_class_modification_node = element_modification_node.modification().class_modification()
+                all_edits += make_edits_for_modifications(next_class_modification_node, requested_modification_value, parser)
+            else:
+                edit = Edit.make_replace(f'={requested_modification_value}')
+                # replace the modification node with our value
+                all_edits.append(edit(element_modification_node.modification()))
+
+    # remaining modifications will need to be inserted (matched modification were removed from the dict)
+    if requested_modifications:
+        new_modifications_string = build_modifications(requested_modifications)
+        edit = Edit.make_insert(', ' + new_modifications_string, insert_after=True)
+        all_edits.append(edit(class_modification_node.argument_list()))
+
+    return all_edits
+
+
 class ModelAnnotationTransformation:
     def __init__(self, modifications):
         self.modifications = modifications
 
     def build_edits(self, tree, parser):
-        def build_modifications(modifications):
-            """returns a string with modifications formatted properly"""
-            mod_strings = []
-            for mod_name, mod_value in modifications.items():
-                if isinstance(mod_value, dict):
-                    # treat the modification as a class_modification
-                    mod_strings.append(f'{mod_name}({build_modifications(mod_value)})')
-                else:
-                    # treat the modification as a simple assignment
-                    mod_strings.append(f'{mod_name}={mod_value}')
-            return ', '.join(mod_strings)
-
         # try to find the model annotation
         model_annotation_xpath = 'stored_definition/class_definition/class_specifier/long_class_specifier/composition/model_annotation'
         model_annotation_node = XPath.XPath.findAll(tree, model_annotation_xpath, parser)
@@ -56,54 +108,52 @@ class ModelAnnotationTransformation:
             edit = Edit.make_insert(f'\n\tannotation({build_modifications(self.modifications)});')
             return SimpleTransformation(selector, edit).build_edits(tree, parser)
 
-        def make_edits_for_modifications(class_modification_node, modifications):
-            """Constructs a list of edits required to update the node with the
-            provided modifications.
-
-            :param class_modification_node: modelicaParser.Class_modificationContext
-            :param modifications: dict
-            """
-            requested_modifications = deepcopy(modifications)
-            overwrite_modifications = requested_modifications.pop('OVERWRITE_MODIFICATIONS', False)
-            if overwrite_modifications:
-                # don't care about selectively updating existing values
-                # just overwrite any existing modifications
-                new_modifications_string = build_modifications(requested_modifications)
-                edit = Edit.make_replace(new_modifications_string)
-                # replace the entire argument_list with our new modifications
-                return [edit(class_modification_node.argument_list())]
-
-            all_edits = []
-            element_modification_xpath = 'class_modification/argument_list/argument/element_modification_or_replaceable/element_modification'
-            element_modification_nodes = XPath.XPath.findAll(class_modification_node, element_modification_xpath, parser)
-
-            # iterate through the existing element modifications
-            for element_modification_node in element_modification_nodes:
-                # check if there's a request to update this modification
-                element_modification_name = element_modification_node.name().getText()
-                if element_modification_name in requested_modifications:
-                    # found a modification to update
-                    requested_modification_value = requested_modifications.pop(element_modification_name)
-                    if isinstance(requested_modification_value, dict):
-                        # recursively make edits for this modification
-                        next_class_modification_node = element_modification_node.modification().class_modification()
-                        all_edits += make_edits_for_modifications(next_class_modification_node, requested_modification_value)
-                    else:
-                        edit = Edit.make_replace(f'={requested_modification_value}')
-                        # replace the modification node with our value
-                        all_edits.append(edit(element_modification_node.modification()))
-
-            # remaining modifications will need to be inserted (matched modification were removed from the dict)
-            if requested_modifications:
-                new_modifications_string = build_modifications(requested_modifications)
-                edit = Edit.make_insert(', ' + new_modifications_string, insert_after=True)
-                all_edits.append(edit(class_modification_node.argument_list()))
-
-            return all_edits
-
         # model annotation exists, recursively update or insert the modifications
         model_annotation_node = model_annotation_node[0]
         return make_edits_for_modifications(
             model_annotation_node.annotation().class_modification(),
-            self.modifications
+            self.modifications,
+            parser,
         )
+
+
+class ComponentModificationsTransformation:
+    def __init__(self, type_, identifier, modifications):
+        """Provides a transformation that inserts or updates a component's
+        modifications
+
+        :param type_: string, component type
+        :param identifier: string, component identifier
+        :param modifications: dict, modifications to update
+        """
+        self._type = type_
+        self._identifier = identifier
+        self._modifications = modifications
+
+    def build_edits(self, tree, parser):
+        # try to find the component declaration
+        component_declaration_selector = ComponentDeclarationSelector(self._type, self._identifier)
+        component_declaration_nodes = component_declaration_selector.apply_to_root(tree, parser)
+
+        # if we failed to find the component declaration, do nothing
+        if len(component_declaration_nodes) == 0:
+            return []
+
+        # for each selected declaration node, try to build edits
+        all_component_edits = []
+        for idx, component_declaration_node in enumerate(component_declaration_nodes):
+            class_modification_node = None
+            try:
+                class_modification_node = component_declaration_node.declaration().modification().class_modification()
+            except Exception as e:
+                logger.debug(str(e), exc_info=True)
+                logger.warning(f'Failed to find class_modification context for #{idx} component_declaration where type="{self._type}" and identifier="{self._identifier}"; skipping modification updates')
+                continue
+
+            all_component_edits += make_edits_for_modifications(
+                class_modification_node,
+                self._modifications,
+                parser
+            )
+
+        return all_component_edits

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -30,7 +30,7 @@ class TestComponentBuilder(TestCase):
 
         # Act
         component_builder = ComponentBuilder(insert_index=insert_index, type_='CustomType', identifier='MyComponent')
-        component_builder.set_argument('k', 10)
+        component_builder.set_modification('k', 10)
         component_builder.add_annotation('Placement(transformation(extent{{10, 16}, {0, 26}}))')
 
         transformer = Transformer(os.path.join(self.data_dir, 'DCMotor.mo'))
@@ -57,7 +57,7 @@ class TestComponentBuilder(TestCase):
 
         # Act
         component_builder = ComponentBuilder(insert_index=insert_index, type_='CustomType', identifier='MyComponent')
-        component_builder.set_argument('k', 10)
+        component_builder.set_modification('k', 10)
         component_builder.add_annotation('Placement(transformation(extent{{10, 16}, {0, 26}}))')
 
         transformer = Transformer(os.path.join(self.data_dir, 'DCMotor.mo'))
@@ -84,7 +84,7 @@ class TestComponentBuilder(TestCase):
 
         # Act
         component_builder = ComponentBuilder(insert_index=insert_index, type_='CustomType', identifier='MyComponent')
-        component_builder.set_argument('k', 10)
+        component_builder.set_modification('k', 10)
         component_builder.add_annotation('Placement(transformation(extent{{10, 16}, {0, 26}}))')
 
         transformer = Transformer(os.path.join(self.data_dir, 'DCMotor.mo'))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -227,52 +227,52 @@ class TestModel(TestCase, DiffAssertions):
         self.assertNoAdditions(source_file, self.result)
         self.assertHasDeletions(source_file, self.result, ['Resistor R(R=100);'])
 
-    def test_model_update_component_argument(self):
+    def test_model_update_component_modification(self):
         # Setup
         source_file = os.path.join(self.data_dir, 'DCMotor.mo')
         model = Model(source_file)
 
         # Act
-        model.update_component_argument('Resistor', 'R', 'R', '54321')
+        model.update_component_modification('Resistor', 'R', 'R', '54321')
         self.result = model.execute()
 
         # Assert
         self.assertHasAdditions(source_file, self.result, ['Resistor R(R=54321);'])
         self.assertHasDeletions(source_file, self.result, ['Resistor R(R=100);'])
 
-    def test_model_update_component_argument_conditional_true(self):
+    def test_model_update_component_modification_conditional_true(self):
         # Setup
         source_file = os.path.join(self.data_dir, 'DCMotor.mo')
         model = Model(source_file)
 
         # Act
-        model.update_component_argument('Resistor', 'R', 'R', '54321', if_value='100')
+        model.update_component_modification('Resistor', 'R', 'R', '54321', if_value='100')
         self.result = model.execute()
 
         # Assert
         self.assertHasAdditions(source_file, self.result, ['Resistor R(R=54321);'])
         self.assertHasDeletions(source_file, self.result, ['Resistor R(R=100);'])
 
-    def test_model_update_component_argument_conditional_true_w_whitespace(self):
+    def test_model_update_component_modification_conditional_true_w_whitespace(self):
         # Setup
         source_file = os.path.join(self.data_dir, 'DCMotor.mo')
         model = Model(source_file)
 
         # Act
-        model.update_component_argument('Resistor', 'R', 'R', '54321', if_value='  100\n')
+        model.update_component_modification('Resistor', 'R', 'R', '54321', if_value='  100\n')
         self.result = model.execute()
 
         # Assert
         self.assertHasAdditions(source_file, self.result, ['Resistor R(R=54321);'])
         self.assertHasDeletions(source_file, self.result, ['Resistor R(R=100);'])
 
-    def test_model_update_component_argument_conditional_false(self):
+    def test_model_update_component_modification_conditional_false(self):
         # Setup
         source_file = os.path.join(self.data_dir, 'DCMotor.mo')
         model = Model(source_file)
 
         # Act
-        model.update_component_argument('Resistor', 'R', 'R', '54321', if_value='bogus_value')
+        model.update_component_modification('Resistor', 'R', 'R', '54321', if_value='bogus_value')
         self.result = model.execute()
 
         # Assert

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -186,7 +186,7 @@ class TestModel(TestCase, DiffAssertions):
 
         # Act
         model.insert_component('FancyClass', 'myInstance',
-                               arguments={'arg1': '1234'}, string_comment='my comment',
+                               modifications={'arg1': '1234'}, string_comment='my comment',
                                annotations=['my annotation'], insert_index=0)
         self.result = model.execute()
 
@@ -201,10 +201,10 @@ class TestModel(TestCase, DiffAssertions):
 
         # Act
         model.insert_component('FancyClass', 'myInstance',
-                               arguments={'arg1': '1234'}, string_comment='my comment',
+                               modifications={'arg1': '1234'}, string_comment='my comment',
                                annotations=['my annotation'])
         model.insert_component('AnotherClass', 'anotherInstance',
-                               arguments={'x': '"hello"'}, string_comment='this is another class',
+                               modifications={'x': '"hello"'}, string_comment='this is another class',
                                annotations=['abc'])
         self.result = model.execute()
 


### PR DESCRIPTION
### Changes
- refactored out some helper methods from ModelAnnotationTransformation for reuse
- BREAKING: changed model api (and selector) to use "modification" rather than "argument". See 8c2d315 
- BREAKING: changed builder api to use "modification" rather than "argument". See d7a0507

### Additions
- Created new ComponentModificationsTransformation class which upserts modifications into a component declaration
- created Model method update_component_modifications which uses the new transformation

### Issues
#15 