### PR TITLE
Remove install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,4 @@ if __name__ == "__main__":
     setup(
         use_pyscaffold=True,
         cmdclass={"update_licenses": UpdateLicenses},
-        install_requires=[
-            "antlr4-python3-runtime==4.8"
-        ],
     )


### PR DESCRIPTION
since we are using PyScaffold we don't need install_requires defined in setup.py.