### PR TITLE
refactor: add configurable, naive indentation for inserted modifications

### DIFF
--- a/modelica_builder/config.py
+++ b/modelica_builder/config.py
@@ -1,0 +1,11 @@
+"""
+****************************************************************************************************
+:copyright (c) 2020, Alliance for Sustainable Energy, LLC.
+All rights reserved.
+****************************************************************************************************
+"""
+
+# global config variables
+# If true, then each inserted component/annotation argument will be indented on a new line
+INDENT_INSERTED_COMPONENT_ARGS = False
+INDENT_INSERTED_ANNOTATION_ARGS = False

--- a/modelica_builder/transformation.py
+++ b/modelica_builder/transformation.py
@@ -6,18 +6,18 @@ All rights reserved.
 """
 
 
-from copy import deepcopy
 import logging
+from copy import deepcopy
 
 from antlr4.xpath import XPath
 
+from modelica_builder import config
 from modelica_builder.edit import Edit
 from modelica_builder.selector import (
     ComponentDeclarationSelector,
     EquationSectionSelector,
-    NthChildSelector,
+    NthChildSelector
 )
-
 
 logger = logging.getLogger(__name__)
 
@@ -32,32 +32,54 @@ class SimpleTransformation:
         return [self.edit(node) for node in selected_nodes]
 
 
-def build_modifications(modifications):
-    """returns a string with modifications formatted properly"""
+def build_modifications(modifications, depth=1, indented=True):
+    """returns a string with modifications formatted properly
+
+    :param modifications: dict
+    :param depth: int, current modification depth, used for determining code indentation
+    :param indent: bool, if true each inserted modification will be indented on new line
+    :return: string
+    """
     mod_strings = []
     for mod_name, mod_value in modifications.items():
         if isinstance(mod_value, dict):
             # treat the modification as a class_modification
-            mod_strings.append(f'{mod_name}({build_modifications(mod_value)})')
+            mod_strings.append(f'{mod_name}({build_modifications(mod_value, depth + 1, indented)})')
         else:
             # treat the modification as a simple assignment
             mod_strings.append(f'{mod_name}={mod_value}')
-    return ', '.join(mod_strings)
+
+    if indented:
+        # depth + 1 because we assume the _root_ thing we're modifying in the
+        # modelica code is already indented once
+        # e.g. a component declaration is usually indented once
+        indent_depth = depth + 1
+        indentation = '\n' + '\t' * indent_depth
+    else:
+        indentation = ''
+
+    return indentation + f',{indentation}'.join(mod_strings)
 
 
-def make_edits_for_modifications(class_modification_node, modifications, parser):
+def make_edits_for_modifications(class_modification_node, modifications, parser, depth=1, indented=False):
     """Constructs a list of edits required to update the node with the
     provided modifications.
 
     :param class_modification_node: modelicaParser.Class_modificationContext
     :param modifications: dict
+    :param parser: antlr4.Parser
+    :param depth: int, current modification depth, used for determining code indentation
+    :param indent: bool, if true each inserted modification will be indented on new line
     """
     requested_modifications = deepcopy(modifications)
     overwrite_modifications = requested_modifications.pop('OVERWRITE_MODIFICATIONS', False)
     if overwrite_modifications:
         # don't care about selectively updating existing values
         # just overwrite any existing modifications
-        new_modifications_string = build_modifications(requested_modifications)
+        new_modifications_string = build_modifications(
+            requested_modifications,
+            depth=depth,
+            indented=indented)
         edit = Edit.make_replace(new_modifications_string)
         # replace the entire argument_list with our new modifications
         return [edit(class_modification_node.argument_list())]
@@ -76,7 +98,12 @@ def make_edits_for_modifications(class_modification_node, modifications, parser)
             if isinstance(requested_modification_value, dict):
                 # recursively make edits for this modification
                 next_class_modification_node = element_modification_node.modification().class_modification()
-                all_edits += make_edits_for_modifications(next_class_modification_node, requested_modification_value, parser)
+                all_edits += make_edits_for_modifications(
+                    next_class_modification_node,
+                    requested_modification_value,
+                    parser,
+                    depth=depth + 1,
+                    indented=indented)
             else:
                 edit = Edit.make_replace(f'={requested_modification_value}')
                 # replace the modification node with our value
@@ -84,7 +111,10 @@ def make_edits_for_modifications(class_modification_node, modifications, parser)
 
     # remaining modifications will need to be inserted (matched modification were removed from the dict)
     if requested_modifications:
-        new_modifications_string = build_modifications(requested_modifications)
+        new_modifications_string = build_modifications(
+            requested_modifications,
+            depth=depth,
+            indented=indented)
         edit = Edit.make_insert(', ' + new_modifications_string, insert_after=True)
         all_edits.append(edit(class_modification_node.argument_list()))
 
@@ -105,7 +135,7 @@ class ModelAnnotationTransformation:
                         .chain(NthChildSelector(-1))
                         .assert_count(1, 'Failed to find end of the equation section'))
 
-            edit = Edit.make_insert(f'\n\tannotation({build_modifications(self.modifications)});')
+            edit = Edit.make_insert(f'\n\tannotation({build_modifications(self.modifications, indented=False)});')
             return SimpleTransformation(selector, edit).build_edits(tree, parser)
 
         # model annotation exists, recursively update or insert the modifications
@@ -114,6 +144,7 @@ class ModelAnnotationTransformation:
             model_annotation_node.annotation().class_modification(),
             self.modifications,
             parser,
+            indented=config.INDENT_INSERTED_ANNOTATION_ARGS,
         )
 
 
@@ -153,7 +184,8 @@ class ComponentModificationsTransformation:
             all_component_edits += make_edits_for_modifications(
                 class_modification_node,
                 self._modifications,
-                parser
+                parser,
+                indented=config.INDENT_INSERTED_COMPONENT_ARGS,
             )
 
         return all_component_edits

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -10,6 +10,7 @@ import os
 import tempfile
 from unittest import TestCase
 
+from modelica_builder import config
 from modelica_builder.model import Model
 
 from .tests import DiffAssertions
@@ -17,6 +18,10 @@ from .tests import DiffAssertions
 
 class TestModel(TestCase, DiffAssertions):
     def setUp(self):
+        # simplify indentation to make diffing simpler
+        config.INDENT_INSERTED_COMPONENT_ARGS = False
+        config.INDENT_INSERTED_ANNOTATION_ARGS = False
+
         self.result = None
         self.data_dir = os.path.join(os.path.dirname(__file__), 'data')
         self.output_dir = os.path.join(os.path.dirname(__file__), 'output')
@@ -640,4 +645,38 @@ end Test;"""
         ])
         self.assertHasDeletions(source_file, self.result, [
             'Resistor R(modA=100, modB(modC=200, modD=300));'
+        ])
+
+    def test_model_update_component_modifications_adds_newlines_correctly(self):
+        # Setup
+        # NOTE: changing the indentation settings
+        config.INDENT_INSERTED_COMPONENT_ARGS = True
+        mo_file = """
+model Test
+    Resistor R(R=1);
+equation
+end Test;"""
+        source_file = self.create_tmp_file(mo_file)
+        model = Model(source_file)
+
+        # Act
+        model.update_component_modifications(
+            'Resistor', 'R', {
+                'modB': {
+                    'modZ': 555,
+                },
+                'inserted': '321'
+            },
+        )
+        self.result = model.execute()
+
+        # Assert
+        self.assertHasAdditions(source_file, self.result, [
+            'Resistor R(R=1,',
+            'modB(',
+            'modZ=555),',
+            'inserted=321);',
+        ])
+        self.assertHasDeletions(source_file, self.result, [
+            'Resistor R(R=1);'
         ])


### PR DESCRIPTION
### Changes
- add a config.py file for setting some indentation preferences.
- based on config, optionally indent inserted annotation or component modifications