### PR TITLE
add replace argument name method

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -222,21 +222,21 @@ htmlhelp_basename = 'modelica_builder-doc'
 # -- Options for LaTeX output --------------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-# 'papersize': 'letterpaper',
+    # The paper size ('letterpaper' or 'a4paper').
+    # 'papersize': 'letterpaper',
 
-# The font size ('10pt', '11pt' or '12pt').
-# 'pointsize': '10pt',
+    # The font size ('10pt', '11pt' or '12pt').
+    # 'pointsize': '10pt',
 
-# Additional stuff for the LaTeX preamble.
-# 'preamble': '',
+    # Additional stuff for the LaTeX preamble.
+    # 'preamble': '',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'user_guide.tex', u'modelica-builder Documentation',
-   u'Nicholas Long', 'manual'),
+    ('index', 'user_guide.tex', u'modelica-builder Documentation',
+     u'Nicholas Long', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/modelica_builder/edit.py
+++ b/modelica_builder/edit.py
@@ -69,7 +69,7 @@ class Edit:
         def insert(node):
             start, stop = modelica_parser.get_span(node)
             if insert_after:
-                start = stop + 1
+                start = stop
 
             # set stop to start, we aren't removing any data
             stop = start
@@ -92,14 +92,9 @@ class Edit:
         # entire document for every edit
         # O(m*n), m = bytes in document, n = number of edits
         for edit in ordered_edits:
-            # catch the case where the name is to replaced which is only one character. The `get_span` method
-            # will set the edit.stop to None if the length is only one.
-            if edit.stop is None:
-                # if the length was 0 then, return the document removing only the one 1 character.
-                document = document[:edit.start] + document[edit.start + 1:]
-            elif edit.start != edit.stop:
-                # remove edit span
-                document = document[:edit.start] + document[edit.stop + 1:]
+            # remove edit span
+            if edit.start != edit.stop:
+                document = document[:edit.start] + document[edit.stop:]
 
             # insert data at the start of span
             if edit.data is not None:

--- a/modelica_builder/edit.py
+++ b/modelica_builder/edit.py
@@ -95,7 +95,7 @@ class Edit:
             # catch the case where the name is to replaced which is only one character. The `get_span` method
             # will set the edit.stop to None if the length is only one.
             if edit.stop is None:
-                # only removing the document that 1 character.
+                # if the length was 0 then, return the document removing only the one 1 character.
                 document = document[:edit.start] + document[edit.start + 1:]
             elif edit.start != edit.stop:
                 # remove edit span

--- a/modelica_builder/edit.py
+++ b/modelica_builder/edit.py
@@ -92,8 +92,13 @@ class Edit:
         # entire document for every edit
         # O(m*n), m = bytes in document, n = number of edits
         for edit in ordered_edits:
-            # remove edit span
-            if edit.start != edit.stop:
+            # catch the case where the name is to replaced which is only one character. The `get_span` method
+            # will set the edit.stop to None if the length is only one.
+            if edit.stop is None:
+                # only removing the document that 1 character.
+                document = document[:edit.start] + document[edit.start + 1:]
+            elif edit.start != edit.stop:
+                # remove edit span
                 document = document[:edit.start] + document[edit.stop + 1:]
 
             # insert data at the start of span

--- a/modelica_builder/modelica_parser/utils.py
+++ b/modelica_builder/modelica_parser/utils.py
@@ -46,27 +46,19 @@ def is_terminal_node(node):
 
 
 def get_span(node):
-    """get the character start and end of a node
+    """get the character start and end of a node. The start and stop follows python's
+    slice notation, ie the node ends at stop-1. In other words:
+    Start is the index of the first character
+    Stop is the index of the first character after the end of the node.
 
     :param node: object or dict, node to get span
     :return: start, stop, character indices for start and stop of node
     """
     # allow dicts for easy mocking
     if type(node) is dict:
-        return node['start'], node['stop']
+        return node['start'], node['stop'] + 1
 
     if is_terminal_node(node):
-        return node.symbol.start, node.symbol.stop
+        return node.symbol.start, node.symbol.stop + 1
 
-    if type(node) is modelicaParser.ModificationContext:
-        return node.stop.start, node.stop.stop
-
-    # The name context is whened when replacing the name of an argument. If the length of the string is only
-    # one character, then set the end to None.
-    if type(node) is modelicaParser.NameContext:
-        if node.start.start == node.stop.stop:
-            return node.start.start, None
-        else:
-            return node.start.start, node.stop.stop
-
-    return node.start.start, node.stop.stop
+    return node.start.start, node.stop.stop + 1

--- a/modelica_builder/modelica_parser/utils.py
+++ b/modelica_builder/modelica_parser/utils.py
@@ -61,7 +61,8 @@ def get_span(node):
     if type(node) is modelicaParser.ModificationContext:
         return node.stop.start, node.stop.stop
 
-    # The name context is whened when replacing the name of an argument. If the
+    # The name context is whened when replacing the name of an argument. If the length of the string is only
+    # one character, then set the end to None.
     if type(node) is modelicaParser.NameContext:
         if node.start.start == node.stop.stop:
             return node.start.start, None

--- a/modelica_builder/modelica_parser/utils.py
+++ b/modelica_builder/modelica_parser/utils.py
@@ -58,4 +58,14 @@ def get_span(node):
     if is_terminal_node(node):
         return node.symbol.start, node.symbol.stop
 
+    if type(node) is modelicaParser.ModificationContext:
+        return node.stop.start, node.stop.stop
+
+    # The name context is whened when replacing the name of an argument. If the
+    if type(node) is modelicaParser.NameContext:
+        if node.start.start == node.stop.stop:
+            return node.start.start, None
+        else:
+            raise Exception("This case has not been handled.")
+
     return node.start.start, node.stop.stop

--- a/modelica_builder/modelica_parser/utils.py
+++ b/modelica_builder/modelica_parser/utils.py
@@ -67,6 +67,6 @@ def get_span(node):
         if node.start.start == node.stop.stop:
             return node.start.start, None
         else:
-            raise Exception("This case has not been handled.")
+            return node.start.start, node.stop.stop
 
     return node.start.start, node.stop.stop

--- a/modelica_builder/selector.py
+++ b/modelica_builder/selector.py
@@ -230,7 +230,7 @@ class ComponentModificationNameSelector(Selector):
             if modification_name_text == self._modification_name:
                 filtered_modifications.append(element_modification)
 
-        # get the argument expressions (ie argument values)
+        # get the argument names
         results = []
         for element_modification in filtered_modifications:
             xpath = '//name'

--- a/modelica_builder/selector.py
+++ b/modelica_builder/selector.py
@@ -21,6 +21,7 @@ class Selector(ABC):
     BASE_PATH = DEFAULT_BASE_PATH
 
     """Selector is the base class for all selectors"""
+
     def __init__(self):
         self._chained_selector = None
         self._assert_count = None
@@ -200,6 +201,40 @@ class ComponentModificationValueSelector(Selector):
                 if re.sub(r"\s*", "", a) == re.sub(r"\s*", "", b):
                     filtered_results.append(result)
             results = filtered_results
+
+        return results
+
+
+class ComponentModificationNameSelector(Selector):
+    """ComponentModificationSelector returns modifications to component
+    declarations
+    """
+    BASE_PATH = 'stored_definition/class_definition/class_specifier/long_class_specifier/composition/element_list/element/component_clause/component_list/component_declaration'
+
+    def __init__(self, modification_name):
+        """
+        :param modification_name: str, mane of the modification to select
+        """
+
+        self._modification_name = modification_name
+        super().__init__()
+
+    def _select(self, base, parser):
+        xpath = 'component_declaration/declaration/modification/class_modification/argument_list/argument/element_modification_or_replaceable/element_modification'
+        element_modifications = XPath.XPath.findAll(base, xpath, parser)
+
+        # filter modifications (ie arguments) to those that match our name
+        filtered_modifications = []
+        for element_modification in element_modifications:
+            modification_name_text = element_modification.name().getText()
+            if modification_name_text == self._modification_name:
+                filtered_modifications.append(element_modification)
+
+        # get the argument expressions (ie argument values)
+        results = []
+        for element_modification in filtered_modifications:
+            xpath = '//name'
+            results.extend(XPath.XPath.findAll(element_modification, xpath, parser))
 
         return results
 

--- a/modelica_builder/transformation.py
+++ b/modelica_builder/transformation.py
@@ -105,7 +105,7 @@ def make_edits_for_modifications(class_modification_node, modifications, parser,
                     depth=depth + 1,
                     indented=indented)
             else:
-                edit = Edit.make_replace(f'={requested_modification_value}')
+                edit = Edit.make_replace(f'{requested_modification_value}')
                 # replace the modification node with our value
                 all_edits.append(edit(element_modification_node.modification()))
 

--- a/modelica_builder/transformation.py
+++ b/modelica_builder/transformation.py
@@ -105,7 +105,7 @@ def make_edits_for_modifications(class_modification_node, modifications, parser,
                     depth=depth + 1,
                     indented=indented)
             else:
-                edit = Edit.make_replace(f'{requested_modification_value}')
+                edit = Edit.make_replace(f'={requested_modification_value}')
                 # replace the modification node with our value
                 all_edits.append(edit(element_modification_node.modification()))
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -539,6 +539,28 @@ end Test;"""
             'k=10'
         ])
 
+    def test_model_rename_argument_more_than_one_char(self):
+        mo_file = """
+model Test
+  Resistor R(Resistance=100);
+equation
+end Test;"""
+        source_file = self.create_tmp_file(mo_file)
+        model = Model(source_file)
+
+        model.rename_component_argument(
+            'Resistor', 'R', 'Resistance', 'R'
+        )
+        self.result = model.execute()
+
+        # Assert
+        self.assertHasAdditions(source_file, self.result, [
+            'R=100',
+        ])
+        self.assertHasDeletions(source_file, self.result, [
+            'Resistance=10'
+        ])
+
     def test_model_update_component_modifications_when_modification_is_nested(self):
         # Setup
         mo_file = """

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5,7 +5,6 @@ All rights reserved.
 ****************************************************************************************************
 """
 
-
 import os
 import tempfile
 from unittest import TestCase
@@ -196,7 +195,8 @@ class TestModel(TestCase, DiffAssertions):
         self.result = model.execute()
 
         # Assert
-        self.assertHasAdditions(source_file, self.result, ['FancyClass myInstance(arg1=1234) "my comment" annotation(my annotation);'])
+        self.assertHasAdditions(source_file, self.result,
+                                ['FancyClass myInstance(arg1=1234) "my comment" annotation(my annotation);'])
         self.assertNoDeletions(source_file, self.result)
 
     def test_model_insert_component_multiple(self):
@@ -303,11 +303,13 @@ class TestModel(TestCase, DiffAssertions):
         model = Model(source_file)
 
         # Act
-        model.add_parameter('String', 'myParam', string_comment='a comment', assigned_value='"supercalifragilisticexpialidocious"')
+        model.add_parameter('String', 'myParam', string_comment='a comment',
+                            assigned_value='"supercalifragilisticexpialidocious"')
         self.result = model.execute()
 
         # Assert
-        self.assertHasAdditions(source_file, self.result, ['parameter String myParam="supercalifragilisticexpialidocious" "a comment"'])
+        self.assertHasAdditions(source_file, self.result,
+                                ['parameter String myParam="supercalifragilisticexpialidocious" "a comment"'])
         self.assertNoDeletions(source_file, self.result)
 
     def test_model_remove_first_component_and_add_param(self):
@@ -394,7 +396,8 @@ end Test;"""
         self.result = model.execute()
 
         # Assert
-        self.assertHasAdditions(source_file, self.result, ['annotation(rootModification=321, insertedModification=555);'])
+        self.assertHasAdditions(source_file, self.result,
+                                ['annotation(rootModification=321, insertedModification=555);'])
         self.assertHasDeletions(source_file, self.result, ['annotation(rootModification=321);'])
 
     def test_model_update_annotation_can_update_and_insert(self):
@@ -415,8 +418,10 @@ end Test;"""
         self.result = model.execute()
 
         # Assert
-        self.assertHasAdditions(source_file, self.result, ['annotation(rootModification=100, rootModification2(childA=0, childB=123, childC=abc), insertedModification=555);'])
-        self.assertHasDeletions(source_file, self.result, ['annotation(rootModification=321, rootModification2(childA=0, childB=1));'])
+        self.assertHasAdditions(source_file, self.result, [
+            'annotation(rootModification=100, rootModification2(childA=0, childB=123, childC=abc), insertedModification=555);'])
+        self.assertHasDeletions(source_file, self.result,
+                                ['annotation(rootModification=321, rootModification2(childA=0, childB=1));'])
 
     def test_model_update_annotation_and_add_connect(self):
         """Model annotation should always the last statement for the model"""
@@ -443,7 +448,8 @@ end Test;"""
         ])
         self.assertNoDeletions(source_file, self.result)
         # make sure the annotation was inserted at the end
-        self.assertIn('annotation(rootModification=100);\nend Test;', self.result, 'Annotation should be at the END of the model')
+        self.assertIn('annotation(rootModification=100);\nend Test;', self.result,
+                      'Annotation should be at the END of the model')
 
     def test_model_update_annotation_can_overwrite_existing_modifications(self):
         # Setup
@@ -514,6 +520,23 @@ end Test;"""
         ])
         self.assertHasDeletions(source_file, self.result, [
             'Resistor R(R=100);'
+        ])
+
+    def test_model_rename_argument(self):
+        source_file = os.path.join(self.data_dir, 'DCMotor.mo')
+        model = Model(source_file)
+
+        model.rename_component_argument(
+            'ElectroMechanicalElement', 'EM', 'k', 'new_arg_name'
+        )
+        self.result = model.execute()
+
+        # Assert
+        self.assertHasAdditions(source_file, self.result, [
+            'new_arg_name=10',
+        ])
+        self.assertHasDeletions(source_file, self.result, [
+            'k=10'
         ])
 
     def test_model_update_component_modifications_when_modification_is_nested(self):

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -28,6 +28,7 @@ class TestSelectors(TestCase, ASTAssertions):
         # Setup
         class NoneSelector(Selector):
             """NoneSelector selects nothing"""
+
             def _select(self, root, parser):
                 return []
 
@@ -43,6 +44,7 @@ class TestSelectors(TestCase, ASTAssertions):
         # Setup
         class OneSelector(Selector):
             """OneSelector selects one node"""
+
             def _select(self, root, parser):
                 # note that we aren't really using a node from tree
                 # it shouldn't matter for this test


### PR DESCRIPTION
* The `get_span` method is causing some issues. There seems to be many conditions on the `get_span` method. @macintoshpie -- can you take a look at the one failing test. There is a extra `1` in the ChildB element which is from the original list. This is caused by the `get_span` method. Let me know what you think!