### PR TITLE
Fix/windows newlines

### DIFF
--- a/modelica_builder/model.py
+++ b/modelica_builder/model.py
@@ -307,5 +307,8 @@ class Model(Transformer):
         :param filename: string, name of file
         """
         result = self.execute()
-        with open(filename, 'w') as f:
+        # Setting newline=None here means any \n we added will be translated
+        # to the native OS's line separator:
+        # https://docs.python.org/3.6/library/functions.html#open
+        with open(filename, 'wt', newline=None) as f:
             f.write(result)

--- a/modelica_builder/transformer.py
+++ b/modelica_builder/transformer.py
@@ -40,5 +40,7 @@ class Transformer:
             all_edits += transformation.build_edits(self._tree, self._parser)
 
         # apply the edits
-        with open(self._source, 'r') as f:
+        # Reading with newline='' lets us retain the original newline characters
+        # allowing us to handle files made on Windows with \r\n
+        with open(self._source, 'rt', newline='') as f:
             return Edit.apply_edits(all_edits, f.read())

--- a/tests/data/DCMotorCRLF.mo
+++ b/tests/data/DCMotorCRLF.mo
@@ -1,0 +1,19 @@
+within models;
+
+model DCMotor
+  Resistor R(R=100);
+  Inductor L(L=100);
+  VsourceDC DC(f=10);
+  Ground G;
+  ElectroMechanicalElement EM(k=10, J=10, b=2);
+  Inertia load;
+equation
+  connect(DC.p, R.n);
+  connect(R.p, L.n);
+  connect(L.p, EM.n);
+  connect(EM.p, DC.n);
+  connect(DC.n, G.p);
+  connect(EM.flange, load.flange);
+  connect(fake_port_a, fake_port_b);
+  connect(fake_port_a, fake_port_c);
+end DCMotor;

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -9,7 +9,8 @@ All rights reserved.
 # -*- coding: utf-8 -*-
 
 import os
-from unittest import TestCase
+
+import pytest
 
 from modelica_builder.builder import ComponentBuilder
 from modelica_builder.transformer import Transformer
@@ -17,14 +18,16 @@ from modelica_builder.transformer import Transformer
 from .tests import get_diffs
 
 
-class TestComponentBuilder(TestCase):
-    def setUp(self):
-        self.data_dir = os.path.join(os.path.dirname(__file__), 'data')
-        self.output_dir = os.path.join(os.path.dirname(__file__), 'output')
-        if not os.path.exists(self.output_dir):
-            os.makedirs(self.output_dir)
+@pytest.mark.parametrize("test_file", ["DCMotor.mo", "DCMotorCRLF.mo"])
+class TestComponentBuilder:
+    @classmethod
+    def setup_class(cls):
+        cls.data_dir = os.path.join(os.path.dirname(__file__), 'data')
+        cls.output_dir = os.path.join(os.path.dirname(__file__), 'output')
+        if not os.path.exists(cls.output_dir):
+            os.makedirs(cls.output_dir)
 
-    def test_component_builder_at_index_0(self):
+    def test_component_builder_at_index_0(self, test_file):
         # Setup
         insert_index = 0
 
@@ -33,7 +36,7 @@ class TestComponentBuilder(TestCase):
         component_builder.set_modification('k', 10)
         component_builder.add_annotation('Placement(transformation(extent{{10, 16}, {0, 26}}))')
 
-        transformer = Transformer(os.path.join(self.data_dir, 'DCMotor.mo'))
+        transformer = Transformer(os.path.join(self.data_dir, test_file))
         transformer.add(component_builder.transformation())
 
         result = transformer.execute()
@@ -43,15 +46,15 @@ class TestComponentBuilder(TestCase):
         with open(os.path.join(self.output_dir, 'DCMotor_component_builder_0.mo'), 'w') as file:
             file.write(result)
 
-        with open(os.path.join(self.data_dir, 'DCMotor.mo'), 'r') as f:
+        with open(os.path.join(self.data_dir, test_file), 'r') as f:
             diffs = get_diffs(f.readlines(), result.splitlines(keepends=True))
 
-            self.assertEqual(1, len(diffs['additions']), f'should have 1 addition, has these: {diffs["additions"]}')
-            self.assertEqual(0, len(diffs['deletions']), f'should have 0 deletions, has these: {diffs["deletions"]}')
+            assert 1 == len(diffs['additions']), f'should have 1 addition, has these: {diffs["additions"]}'
+            assert 0 == len(diffs['deletions']), f'should have 0 deletions, has these: {diffs["deletions"]}'
 
-            self.assertIn('CustomType MyComponent(k=10) annotation(Placement(transformation(extent{{10, 16}, {0, 26}}))', diffs['additions'][0])
+            assert 'CustomType MyComponent(k=10) annotation(Placement(transformation(extent{{10, 16}, {0, 26}}))' in diffs['additions'][0]
 
-    def test_component_builder_at_index_1(self):
+    def test_component_builder_at_index_1(self, test_file):
         # Setup
         insert_index = 1
 
@@ -60,7 +63,7 @@ class TestComponentBuilder(TestCase):
         component_builder.set_modification('k', 10)
         component_builder.add_annotation('Placement(transformation(extent{{10, 16}, {0, 26}}))')
 
-        transformer = Transformer(os.path.join(self.data_dir, 'DCMotor.mo'))
+        transformer = Transformer(os.path.join(self.data_dir, test_file))
         transformer.add(component_builder.transformation())
 
         result = transformer.execute()
@@ -70,15 +73,15 @@ class TestComponentBuilder(TestCase):
         with open(os.path.join(self.output_dir, 'DCMotor_component_builder_1.mo'), 'w') as file:
             file.write(result)
 
-        with open(os.path.join(self.data_dir, 'DCMotor.mo'), 'r') as f:
+        with open(os.path.join(self.data_dir, test_file), 'r') as f:
             diffs = get_diffs(f.readlines(), result.splitlines(keepends=True))
 
-            self.assertEqual(1, len(diffs['additions']), f'should have 1 addition, has these: {diffs["additions"]}')
-            self.assertEqual(0, len(diffs['deletions']), f'should have 0 deletions, has these: {diffs["deletions"]}')
+            assert 1 == len(diffs['additions']), f'should have 1 addition, has these: {diffs["additions"]}'
+            assert 0 == len(diffs['deletions']), f'should have 0 deletions, has these: {diffs["deletions"]}'
 
-            self.assertIn('CustomType MyComponent(k=10) annotation(Placement(transformation(extent{{10, 16}, {0, 26}}))', diffs['additions'][0])
+            assert 'CustomType MyComponent(k=10) annotation(Placement(transformation(extent{{10, 16}, {0, 26}}))' in diffs['additions'][0]
 
-    def test_component_builder_at_end(self):
+    def test_component_builder_at_end(self, test_file):
         # Setup
         insert_index = 0
 
@@ -87,7 +90,7 @@ class TestComponentBuilder(TestCase):
         component_builder.set_modification('k', 10)
         component_builder.add_annotation('Placement(transformation(extent{{10, 16}, {0, 26}}))')
 
-        transformer = Transformer(os.path.join(self.data_dir, 'DCMotor.mo'))
+        transformer = Transformer(os.path.join(self.data_dir, test_file))
         transformer.add(component_builder.transformation())
 
         result = transformer.execute()
@@ -97,10 +100,10 @@ class TestComponentBuilder(TestCase):
         with open(os.path.join(self.output_dir, 'DCMotor_component_builder_at_end.mo'), 'w') as file:
             file.write(result)
 
-        with open(os.path.join(self.data_dir, 'DCMotor.mo'), 'r') as f:
+        with open(os.path.join(self.data_dir, test_file), 'r') as f:
             diffs = get_diffs(f.readlines(), result.splitlines(keepends=True))
 
-            self.assertEqual(1, len(diffs['additions']), f'should have 1 addition, has these: {diffs["additions"]}')
-            self.assertEqual(0, len(diffs['deletions']), f'should have 0 deletions, has these: {diffs["deletions"]}')
+            assert 1 == len(diffs['additions']), f'should have 1 addition, has these: {diffs["additions"]}'
+            assert 0 == len(diffs['deletions']), f'should have 0 deletions, has these: {diffs["deletions"]}'
 
-            self.assertIn('CustomType MyComponent(k=10) annotation(Placement(transformation(extent{{10, 16}, {0, 26}}))', diffs['additions'][0])
+            assert 'CustomType MyComponent(k=10) annotation(Placement(transformation(extent{{10, 16}, {0, 26}}))' in diffs['additions'][0]


### PR DESCRIPTION
## changes
- fix handling of files created on Windows, which use \r\n for line separators instead of \n

## issues
Closes #35 