### PR TITLE
update _source filename when calling save_as

### DIFF
--- a/modelica_builder/model.py
+++ b/modelica_builder/model.py
@@ -439,3 +439,6 @@ class Model(Transformer):
         # https://docs.python.org/3.6/library/functions.html#open
         with open(filename, 'wt', newline=None) as f:
             f.write(result)
+
+        # update the source link
+        self._source = filename


### PR DESCRIPTION
The member variable of `_source` was not being updated to the new path when calling `save_as`.