### PR TITLE
Ensure the correct template is loaded when parsing the package

### DIFF
--- a/modelica_builder/package_parser.py
+++ b/modelica_builder/package_parser.py
@@ -99,7 +99,7 @@ class PackageParser(object):
             PackageParser: object of the package parser
         """
         klass = PackageParser(path)
-        if not mbl_version:
+        if within and not mbl_version:
             template = klass.template_env.get_template("package.mot")
         else:
             template = klass.template_env.get_template("package_base.mot")


### PR DESCRIPTION
If we only check for `mbl_version` and not also for `within` the GMT sometimes generates a `within None;` which is incorrect. This way we use the right template.