### PR TITLE
Update GitHub action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
         python-version: ["3.9", "3.12"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,9 +11,7 @@ Version 0.5.2-rc1
 * build(deps-dev): bump requests from 2.31.0 to 2.32.0 by @dependabot in https://github.com/urbanopt/modelica-builder/pull/87
 * Update certifi and jinja by @nllong in https://github.com/urbanopt/modelica-builder/pull/94
 
-
 **Full Changelog**: https://github.com/urbanopt/modelica-builder/compare/v0.5.1...v0.5.2-rc1
-
 
 Version 0.5.1
 =============


### PR DESCRIPTION
* Update the versions of the actions to remove deprecated Node warnings