### PR TITLE
Use explicit newline when saving from model.py

### DIFF
--- a/modelica_builder/model.py
+++ b/modelica_builder/model.py
@@ -433,10 +433,7 @@ class Model(Transformer):
         :param filename: string, name of file
         """
         result = self.execute()
-        # Setting newline=None here means any \n we added will be translated
-        # to the native OS's line separator:
-        # https://docs.python.org/3.6/library/functions.html#open
-        with open(filename, 'wt', newline=None) as f:
+        with open(filename, 'wt', newline='\n') as f:
             f.write(result)
 
         # update the source link


### PR DESCRIPTION
Resolves #90 

Change the newline setting from system-standard to explicitly `\n`. According to the linked issue Windows was generating a double line break, instead of the desired single. Explicitly using a single line break fixes this, and maintains the existing behavior on Unix-like systems.

Note that this is merging into the prep-v0.6.0 branch. This allows this PR to use functionality from that branch, and merge cleanly to be used in v0.6.0.