### PR TITLE
Allow package parser to include subpackages

### DIFF
--- a/modelica_builder/package_parser.py
+++ b/modelica_builder/package_parser.py
@@ -172,10 +172,10 @@ class PackageParser(object):
         # verify that the path exists before saving
         if self.path is None:
             raise ValueError("Path to save the package.mo and package.order files is not set.")
-        
+
         # Ensure the directory exists (important for nested subpackages)
         Path(self.path).mkdir(parents=True, exist_ok=True)
-        
+
         with open(os.path.join(str(self.path), "package.mo"), "w") as f:
             f.write(self.package_data)
 
@@ -267,7 +267,17 @@ class PackageParser(object):
 
         Returns:
             PackageParser: The created subpackage if create_subpackage is True, otherwise self for chaining.
+
+        Raises:
+            ValueError: If create_subpackage is True but self.path is None.
         """
+        # Validate that path exists when creating subpackages
+        if create_subpackage and self.path is None:
+            raise ValueError(
+                f"Cannot create subpackage '{new_model_name}': PackageParser.path is None. "
+                "Either set path during initialization or use create_subpackage=False."
+            )
+
         data = self.order_data.split("\n")
         if insert_at == -1:
             data.append(new_model_name)
@@ -279,7 +289,7 @@ class PackageParser(object):
         self.order_data = self.order_data.replace('\n\n', '\n')
 
         # If create_subpackage is True, create the subpackage structure
-        if create_subpackage and self.path is not None:
+        if create_subpackage:
             subpackage_path = Path(self.path) / new_model_name
             subpackage_path.mkdir(parents=True, exist_ok=True)
 

--- a/modelica_builder/package_parser.py
+++ b/modelica_builder/package_parser.py
@@ -169,10 +169,17 @@ class PackageParser(object):
     def save(self) -> None:
         """Save the updated files to the same location. Also saves all subpackages recursively.
         """
-        with open(os.path.join(os.path.join(str(self.path), "package.mo")), "w") as f:
+        # verify that the path exists before saving
+        if self.path is None:
+            raise ValueError("Path to save the package.mo and package.order files is not set.")
+        
+        # Ensure the directory exists (important for nested subpackages)
+        Path(self.path).mkdir(parents=True, exist_ok=True)
+        
+        with open(os.path.join(str(self.path), "package.mo"), "w") as f:
             f.write(self.package_data)
 
-        with open(os.path.join(os.path.join(str(self.path), "package.order")), "w") as f:
+        with open(os.path.join(str(self.path), "package.order"), "w") as f:
             f.write(self.order_data)
             f.write("\n")
 

--- a/modelica_builder/package_parser.py
+++ b/modelica_builder/package_parser.py
@@ -252,7 +252,7 @@ class PackageParser(object):
         Args:
             new_model_name (str): name of the new model to add to the package order.
             insert_at (int, optional):  location to insert package, if 0 at beginning, -1 at end. Defaults to -1.
-            create_subpackage (bool, optional): If True, create a subpackage directory and PackageParser. Defaults to True.
+            create_subpackage (bool, optional): If True, create a subpackage directory and PackageParser. Defaults to False.
 
         Returns:
             PackageParser: The created subpackage if create_subpackage is True, otherwise self for chaining.

--- a/modelica_builder/package_parser.py
+++ b/modelica_builder/package_parser.py
@@ -84,8 +84,12 @@ class PackageParser(object):
             for order_name in orders:
                 if order_name.lower() == name_lower:
                     # Try to load the existing subpackage
-                    if self.path:
-                        subpackage_path = Path(self.path) / order_name
+                    try:
+                        path = object.__getattribute__(self, 'path')
+                    except AttributeError:
+                        path = None
+                    if path:
+                        subpackage_path = Path(path) / order_name
                         if subpackage_path.exists():
                             subpackage = PackageParser(subpackage_path)
                             object.__getattribute__(self, '_subpackages')[name_lower] = subpackage

--- a/modelica_builder/package_parser.py
+++ b/modelica_builder/package_parser.py
@@ -91,7 +91,7 @@ class PackageParser(object):
                             object.__getattribute__(self, '_subpackages')[name_lower] = subpackage
                             return subpackage
 
-        raise AttributeError(f"Subpackage '{name}' not found. Use add_model('{name}', create_subpackage=True) first.")
+        raise AttributeError(f"Subpackage '{name}' not found. Use add_model('{name}') to create it first.")
 
     def parse_within_statement(self) -> Optional[List[str]]:
         """Read in the package_data and parse out the within statement. The result will

--- a/modelica_builder/package_parser.py
+++ b/modelica_builder/package_parser.py
@@ -80,7 +80,7 @@ class PackageParser(object):
 
         # Check if the subpackage exists in the order but hasn't been loaded yet
         if hasattr(self, 'order_data') and self.order_data:
-            orders = self.order_data.split('\n')
+            orders = [o for o in self.order_data.split('\n') if o.strip()]
             for order_name in orders:
                 if order_name.lower() == name_lower:
                     # Try to load the existing subpackage

--- a/modelica_builder/package_parser.py
+++ b/modelica_builder/package_parser.py
@@ -6,7 +6,7 @@ import os
 import re
 from jinja2 import Environment, FileSystemLoader
 from pathlib import Path
-from typing import Any, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 
 # config for jinga2
@@ -38,6 +38,7 @@ class PackageParser(object):
         self.package_data: Any = None
         self.package_name: Union[str, None] = None
         self.within: Union[list, None] = None
+        self._subpackages: Dict[str, "PackageParser"] = {}
 
         self.load()
 
@@ -55,6 +56,42 @@ class PackageParser(object):
             )
         )
         self.template_env.filters.update(ALL_CUSTOM_FILTERS)
+
+    def __getattr__(self, name: str) -> "PackageParser":
+        """Enable dynamic access to subpackages via attribute notation.
+        
+        Args:
+            name (str): The name of the subpackage (case-insensitive)
+            
+        Returns:
+            PackageParser: The subpackage parser instance
+            
+        Raises:
+            AttributeError: If the subpackage doesn't exist
+        """
+        # Avoid recursion for private attributes
+        if name.startswith('_'):
+            raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
+        
+        # Check if this is a known subpackage
+        name_lower = name.lower()
+        if name_lower in object.__getattribute__(self, '_subpackages'):
+            return object.__getattribute__(self, '_subpackages')[name_lower]
+        
+        # Check if the subpackage exists in the order but hasn't been loaded yet
+        if hasattr(self, 'order_data') and self.order_data:
+            orders = self.order_data.split('\n')
+            for order_name in orders:
+                if order_name.lower() == name_lower:
+                    # Try to load the existing subpackage
+                    if self.path:
+                        subpackage_path = Path(self.path) / order_name
+                        if subpackage_path.exists():
+                            subpackage = PackageParser(subpackage_path)
+                            object.__getattribute__(self, '_subpackages')[name_lower] = subpackage
+                            return subpackage
+        
+        raise AttributeError(f"Subpackage '{name}' not found. Use add_model('{name}', create_subpackage=True) first.")
 
     def parse_within_statement(self) -> Optional[List[str]]:
         """Read in the package_data and parse out the within statement. The result will
@@ -80,7 +117,7 @@ class PackageParser(object):
     def new_from_template(cls,
                           path: Union[str, Path],
                           name: str,
-                          order: list[str],
+                          order: List[str],
                           mbl_version: Union[str, None] = None,
                           within: Union[str, None] = None
                           ) -> "PackageParser":
@@ -126,7 +163,7 @@ class PackageParser(object):
         self.parse_within_statement()
 
     def save(self) -> None:
-        """Save the updated files to the same location
+        """Save the updated files to the same location. Also saves all subpackages recursively.
         """
         with open(os.path.join(os.path.join(str(self.path), "package.mo")), "w") as f:
             f.write(self.package_data)
@@ -134,6 +171,10 @@ class PackageParser(object):
         with open(os.path.join(os.path.join(str(self.path), "package.order")), "w") as f:
             f.write(self.order_data)
             f.write("\n")
+        
+        # Recursively save all subpackages
+        for subpackage in self._subpackages.values():
+            subpackage.save()
 
     def save_as(self, new_path: Union[str, Path]) -> None:
         """Save the package.mo and package.order file to the new path. Be
@@ -156,11 +197,11 @@ class PackageParser(object):
         self.path = new_path
 
     @property
-    def order(self) -> list[str]:
+    def order(self) -> List[str]:
         """Return the order of the packages from the package.order file
 
         Returns:
-            list[str]: list of the loaded models in the package.order file
+            List[str]: list of the loaded models in the package.order file
         """
         data = self.order_data.split("\n")
         if "" in data:
@@ -204,13 +245,17 @@ class PackageParser(object):
         self.package_data = self.package_data.replace(f"within {'.'.join(self.within)};", f"within {'.'.join(new_within_list)};")  # type: ignore
         self.within = new_within_list
 
-    def add_model(self, new_model_name: str, insert_at: int = -1) -> None:
+    def add_model(self, new_model_name: str, insert_at: int = -1, create_subpackage: bool = True) -> "PackageParser":
         """Insert a new model into the package. Note that the order_data is stored as a string right now,
         so there is a bit of a hack to get this to work correctly.
 
         Args:
             new_model_name (str): name of the new model to add to the package order.
             insert_at (int, optional):  location to insert package, if 0 at beginning, -1 at end. Defaults to -1.
+            create_subpackage (bool, optional): If True, create a subpackage directory and PackageParser. Defaults to True.
+            
+        Returns:
+            PackageParser: The created subpackage if create_subpackage is True, otherwise self for chaining.
         """
         data = self.order_data.split("\n")
         if insert_at == -1:
@@ -221,3 +266,28 @@ class PackageParser(object):
 
         # remove any empty lines
         self.order_data = self.order_data.replace('\n\n', '\n')
+        
+        # If create_subpackage is True, create the subpackage structure
+        if create_subpackage and self.path is not None:
+            subpackage_path = Path(self.path) / new_model_name
+            subpackage_path.mkdir(parents=True, exist_ok=True)
+            
+            # Determine the within statement for the subpackage
+            if self.within:
+                subpackage_within = f"{'.'.join(self.within)}.{self.package_name}"
+            else:
+                subpackage_within = self.package_name
+            
+            # Create the subpackage PackageParser
+            subpackage = PackageParser.new_from_template(
+                path=subpackage_path,
+                name=new_model_name,
+                order=[],
+                within=subpackage_within
+            )
+            
+            # Store it for later access
+            self._subpackages[new_model_name.lower()] = subpackage
+            return subpackage
+        
+        return self

--- a/modelica_builder/package_parser.py
+++ b/modelica_builder/package_parser.py
@@ -60,14 +60,22 @@ class PackageParser(object):
     def __getattr__(self, name: str) -> "PackageParser":
         """Enable dynamic access to subpackages via attribute notation.
 
+        This method implements lazy loading of subpackages using a three-step lookup process:
+        1. First checks the `_subpackages` cache for previously loaded subpackages
+        2. If not cached, attempts to load the subpackage from disk if it exists in `order_data`
+        3. Raises AttributeError if the subpackage is not found in either location
+
+        Note: This method may perform disk I/O operations when loading subpackages that haven't
+        been cached yet, which could impact performance if called repeatedly for new subpackages.
+
         Args:
             name (str): The name of the subpackage (case-insensitive)
 
         Returns:
-            PackageParser: The subpackage parser instance
+            PackageParser: The subpackage parser instance, either from cache or newly loaded from disk
 
         Raises:
-            AttributeError: If the subpackage doesn't exist
+            AttributeError: If the subpackage doesn't exist in cache or on disk
         """
         # Avoid recursion for private attributes
         if name.startswith('_'):

--- a/modelica_builder/package_parser.py
+++ b/modelica_builder/package_parser.py
@@ -278,18 +278,25 @@ class PackageParser(object):
                 "Either set path during initialization or use create_subpackage=False."
             )
 
+        # Only add to order_data if not already present
         data = self.order_data.split("\n")
-        if insert_at == -1:
-            data.append(new_model_name)
-        else:
-            data.insert(insert_at, new_model_name)
-        self.order_data = "\n".join(data)
+        if new_model_name not in data:
+            if insert_at == -1:
+                data.append(new_model_name)
+            else:
+                data.insert(insert_at, new_model_name)
+            self.order_data = "\n".join(data)
 
-        # remove any empty lines
-        self.order_data = self.order_data.replace('\n\n', '\n')
+            # remove any empty lines
+            self.order_data = self.order_data.replace('\n\n', '\n')
 
         # If create_subpackage is True, create the subpackage structure
         if create_subpackage:
+            # Check if the subpackage already exists in cache to avoid creating duplicate instances
+            name_lower = new_model_name.lower()
+            if name_lower in self._subpackages:
+                return self._subpackages[name_lower]
+
             subpackage_path = Path(self.path) / new_model_name
             subpackage_path.mkdir(parents=True, exist_ok=True)
 
@@ -308,7 +315,7 @@ class PackageParser(object):
             )
 
             # Store it for later access
-            self._subpackages[new_model_name.lower()] = subpackage
+            self._subpackages[name_lower] = subpackage
             return subpackage
 
         return self

--- a/modelica_builder/package_parser.py
+++ b/modelica_builder/package_parser.py
@@ -245,7 +245,7 @@ class PackageParser(object):
         self.package_data = self.package_data.replace(f"within {'.'.join(self.within)};", f"within {'.'.join(new_within_list)};")  # type: ignore
         self.within = new_within_list
 
-    def add_model(self, new_model_name: str, insert_at: int = -1, create_subpackage: bool = True) -> "PackageParser":
+    def add_model(self, new_model_name: str, insert_at: int = -1, create_subpackage: bool = False) -> "PackageParser":
         """Insert a new model into the package. Note that the order_data is stored as a string right now,
         so there is a bit of a hack to get this to work correctly.
 

--- a/modelica_builder/package_parser.py
+++ b/modelica_builder/package_parser.py
@@ -73,6 +73,17 @@ class PackageParser(object):
         if name.startswith('_'):
             raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
 
+        # Check if this is a class-level attribute or method before treating it as a subpackage
+        # This prevents confusing error messages when a property or method fails
+        if hasattr(type(self), name):
+            # Get the class attribute
+            class_attr = getattr(type(self), name)
+            # If it's a property, call it to get the original error
+            if isinstance(class_attr, property):
+                return class_attr.fget(self)
+            # For other class attributes, raise a generic error
+            raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
+
         # Check if this is a known subpackage
         name_lower = name.lower()
         if name_lower in object.__getattribute__(self, '_subpackages'):

--- a/modelica_builder/package_parser.py
+++ b/modelica_builder/package_parser.py
@@ -59,25 +59,25 @@ class PackageParser(object):
 
     def __getattr__(self, name: str) -> "PackageParser":
         """Enable dynamic access to subpackages via attribute notation.
-        
+
         Args:
             name (str): The name of the subpackage (case-insensitive)
-            
+
         Returns:
             PackageParser: The subpackage parser instance
-            
+
         Raises:
             AttributeError: If the subpackage doesn't exist
         """
         # Avoid recursion for private attributes
         if name.startswith('_'):
             raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
-        
+
         # Check if this is a known subpackage
         name_lower = name.lower()
         if name_lower in object.__getattribute__(self, '_subpackages'):
             return object.__getattribute__(self, '_subpackages')[name_lower]
-        
+
         # Check if the subpackage exists in the order but hasn't been loaded yet
         if hasattr(self, 'order_data') and self.order_data:
             orders = self.order_data.split('\n')
@@ -90,7 +90,7 @@ class PackageParser(object):
                             subpackage = PackageParser(subpackage_path)
                             object.__getattribute__(self, '_subpackages')[name_lower] = subpackage
                             return subpackage
-        
+
         raise AttributeError(f"Subpackage '{name}' not found. Use add_model('{name}', create_subpackage=True) first.")
 
     def parse_within_statement(self) -> Optional[List[str]]:
@@ -171,7 +171,7 @@ class PackageParser(object):
         with open(os.path.join(os.path.join(str(self.path), "package.order")), "w") as f:
             f.write(self.order_data)
             f.write("\n")
-        
+
         # Recursively save all subpackages
         for subpackage in self._subpackages.values():
             subpackage.save()
@@ -253,7 +253,7 @@ class PackageParser(object):
             new_model_name (str): name of the new model to add to the package order.
             insert_at (int, optional):  location to insert package, if 0 at beginning, -1 at end. Defaults to -1.
             create_subpackage (bool, optional): If True, create a subpackage directory and PackageParser. Defaults to True.
-            
+
         Returns:
             PackageParser: The created subpackage if create_subpackage is True, otherwise self for chaining.
         """
@@ -266,18 +266,18 @@ class PackageParser(object):
 
         # remove any empty lines
         self.order_data = self.order_data.replace('\n\n', '\n')
-        
+
         # If create_subpackage is True, create the subpackage structure
         if create_subpackage and self.path is not None:
             subpackage_path = Path(self.path) / new_model_name
             subpackage_path.mkdir(parents=True, exist_ok=True)
-            
+
             # Determine the within statement for the subpackage
             if self.within:
                 subpackage_within = f"{'.'.join(self.within)}.{self.package_name}"
             else:
                 subpackage_within = self.package_name
-            
+
             # Create the subpackage PackageParser
             subpackage = PackageParser.new_from_template(
                 path=subpackage_path,
@@ -285,9 +285,9 @@ class PackageParser(object):
                 order=[],
                 within=subpackage_within
             )
-            
+
             # Store it for later access
             self._subpackages[new_model_name.lower()] = subpackage
             return subpackage
-        
+
         return self

--- a/tests/test_package_parser.py
+++ b/tests/test_package_parser.py
@@ -129,7 +129,7 @@ class PackageParserTest(unittest.TestCase):
             import shutil
             shutil.rmtree(project_path)
         project_path.mkdir(parents=True)
-        
+
         # Create root package
         package = PackageParser.new_from_template(
             project_path,
@@ -137,11 +137,11 @@ class PackageParserTest(unittest.TestCase):
             [],
             mbl_version='12.1.0'
         )
-        
+
         # Add a subpackage
         package.add_model('Districts')
         package.save()  # Save to write files to disk
-        
+
         # Access via attribute notation
         districts = package.districts
         self.assertIsInstance(districts, PackageParser)
@@ -149,7 +149,7 @@ class PackageParserTest(unittest.TestCase):
         self.assertTrue((project_path / 'Districts').exists())
         self.assertTrue((project_path / 'Districts' / 'package.mo').exists())
         self.assertTrue((project_path / 'Districts' / 'package.order').exists())
-        
+
         # Check within statement
         self.assertEqual(districts.within, ['MyProject'])
 
@@ -160,7 +160,7 @@ class PackageParserTest(unittest.TestCase):
             import shutil
             shutil.rmtree(project_path)
         project_path.mkdir(parents=True)
-        
+
         # Create root package
         package = PackageParser.new_from_template(
             project_path,
@@ -168,16 +168,16 @@ class PackageParserTest(unittest.TestCase):
             [],
             mbl_version='12.1.0'
         )
-        
+
         # Add nested subpackages
         package.add_model('Districts')
         package.districts.add_model('Models')
         package.save()  # Save to write files to disk
-        
+
         # Verify structure
         self.assertTrue((project_path / 'Districts' / 'Models').exists())
         self.assertTrue((project_path / 'Districts' / 'Models' / 'package.mo').exists())
-        
+
         # Check within statements
         models = package.districts.models
         self.assertEqual(models.within, ['NestedProject', 'Districts'])
@@ -189,7 +189,7 @@ class PackageParserTest(unittest.TestCase):
             import shutil
             shutil.rmtree(project_path)
         project_path.mkdir(parents=True)
-        
+
         # Create structure
         package = PackageParser.new_from_template(
             project_path,
@@ -197,14 +197,14 @@ class PackageParserTest(unittest.TestCase):
             [],
             mbl_version='12.1.0'
         )
-        
+
         package.add_model('Districts')
         package.districts.add_model('Model1', create_subpackage=False)
         package.districts.add_model('Model2', create_subpackage=False)
-        
+
         # Save only the root
         package.save()
-        
+
         # Verify Districts package.order contains the models
         with open(project_path / 'Districts' / 'package.order') as f:
             content = f.read()
@@ -218,17 +218,17 @@ class PackageParserTest(unittest.TestCase):
             import shutil
             shutil.rmtree(project_path)
         project_path.mkdir(parents=True)
-        
+
         package = PackageParser.new_from_template(
             project_path,
             'ErrorProject',
             [],
             mbl_version='12.1.0'
         )
-        
+
         with self.assertRaises(AttributeError) as context:
             _ = package.nonexistent
-        
+
         self.assertIn('nonexistent', str(context.exception))
 
     def test_case_insensitive_subpackage_access(self):
@@ -238,33 +238,33 @@ class PackageParserTest(unittest.TestCase):
             import shutil
             shutil.rmtree(project_path)
         project_path.mkdir(parents=True)
-        
+
         package = PackageParser.new_from_template(
             project_path,
             'CaseProject',
             [],
             mbl_version='12.1.0'
         )
-        
+
         package.add_model('Districts')
-        
+
         # All these should work
         districts1 = package.districts
         districts2 = package.Districts
         districts3 = package.DISTRICTS
-        
+
         self.assertIs(districts1, districts2)
         self.assertIs(districts2, districts3)
 
     def test_full_workflow(self):
-        """Test the complete workflow from the user's pseudo code"""
+        """Test the complete workflow from example code"""
         project_path = Path(self.output_dir) / 'test_workflow'
         if project_path.exists():
             import shutil
             shutil.rmtree(project_path)
         project_path.mkdir(parents=True)
-        
-        # User's desired pseudo code
+
+        # Example of how we want to access the package
         package = PackageParser.new_from_template(
             project_path,
             'WorkflowProject',
@@ -272,27 +272,27 @@ class PackageParserTest(unittest.TestCase):
             mbl_version='12.1.0'
         )
         package.add_model('Districts')
-        package.districts.add_model('junk')
+        package.districts.add_model('Model_Sigma')
         package.save()
-        
+
         # Verify the structure was created
         self.assertTrue((project_path / 'package.mo').exists())
         self.assertTrue((project_path / 'Districts').exists())
-        self.assertTrue((project_path / 'Districts' / 'junk').exists())
-        self.assertTrue((project_path / 'Districts' / 'junk' / 'package.mo').exists())
-        
+        self.assertTrue((project_path / 'Districts' / 'Model_Sigma').exists())
+        self.assertTrue((project_path / 'Districts' / 'Model_Sigma' / 'package.mo').exists())
+
         # Verify package.order contents
         with open(project_path / 'package.order') as f:
             self.assertIn('Districts', f.read())
-        
+
         with open(project_path / 'Districts' / 'package.order') as f:
-            self.assertIn('junk', f.read())
-        
+            self.assertIn('Model_Sigma', f.read())
+
         # Verify within statements in package.mo files
         with open(project_path / 'Districts' / 'package.mo') as f:
             content = f.read()
             self.assertIn('within WorkflowProject;', content)
-        
-        with open(project_path / 'Districts' / 'junk' / 'package.mo') as f:
+
+        with open(project_path / 'Districts' / 'Model_Sigma' / 'package.mo') as f:
             content = f.read()
             self.assertIn('within WorkflowProject.Districts;', content)

--- a/tests/test_package_parser.py
+++ b/tests/test_package_parser.py
@@ -103,8 +103,8 @@ class PackageParserTest(unittest.TestCase):
         )
         package.save()
 
-        package.add_model('model_delta')
-        package.add_model('model_alpha', 0)
+        package.add_model('model_delta', create_subpackage=False)
+        package.add_model('model_alpha', 0, create_subpackage=False)
         self.assertEqual(len(package.order), 4)
         self.assertListEqual(['model_alpha', 'model_beta', 'model_gamma', 'model_delta'], package.order)
 
@@ -121,3 +121,178 @@ class PackageParserTest(unittest.TestCase):
 
         package.update_within_statement('NewWithin')
         self.assertEqual(package.within, ['NewWithin'])
+
+    def test_add_subpackage_and_access(self):
+        """Test adding a subpackage and accessing it via attribute notation"""
+        project_path = Path(self.output_dir) / 'test_subpackage_project'
+        if project_path.exists():
+            import shutil
+            shutil.rmtree(project_path)
+        project_path.mkdir(parents=True)
+        
+        # Create root package
+        package = PackageParser.new_from_template(
+            project_path,
+            'MyProject',
+            [],
+            mbl_version='12.1.0'
+        )
+        
+        # Add a subpackage
+        package.add_model('Districts')
+        package.save()  # Save to write files to disk
+        
+        # Access via attribute notation
+        districts = package.districts
+        self.assertIsInstance(districts, PackageParser)
+        self.assertEqual(districts.package_name, 'Districts')
+        self.assertTrue((project_path / 'Districts').exists())
+        self.assertTrue((project_path / 'Districts' / 'package.mo').exists())
+        self.assertTrue((project_path / 'Districts' / 'package.order').exists())
+        
+        # Check within statement
+        self.assertEqual(districts.within, ['MyProject'])
+
+    def test_nested_subpackages(self):
+        """Test creating nested subpackages: package.districts.models"""
+        project_path = Path(self.output_dir) / 'test_nested_project'
+        if project_path.exists():
+            import shutil
+            shutil.rmtree(project_path)
+        project_path.mkdir(parents=True)
+        
+        # Create root package
+        package = PackageParser.new_from_template(
+            project_path,
+            'NestedProject',
+            [],
+            mbl_version='12.1.0'
+        )
+        
+        # Add nested subpackages
+        package.add_model('Districts')
+        package.districts.add_model('Models')
+        package.save()  # Save to write files to disk
+        
+        # Verify structure
+        self.assertTrue((project_path / 'Districts' / 'Models').exists())
+        self.assertTrue((project_path / 'Districts' / 'Models' / 'package.mo').exists())
+        
+        # Check within statements
+        models = package.districts.models
+        self.assertEqual(models.within, ['NestedProject', 'Districts'])
+
+    def test_subpackage_save_recursive(self):
+        """Test that saving parent package also saves all subpackages"""
+        project_path = Path(self.output_dir) / 'test_recursive_save'
+        if project_path.exists():
+            import shutil
+            shutil.rmtree(project_path)
+        project_path.mkdir(parents=True)
+        
+        # Create structure
+        package = PackageParser.new_from_template(
+            project_path,
+            'SaveProject',
+            [],
+            mbl_version='12.1.0'
+        )
+        
+        package.add_model('Districts')
+        package.districts.add_model('Model1', create_subpackage=False)
+        package.districts.add_model('Model2', create_subpackage=False)
+        
+        # Save only the root
+        package.save()
+        
+        # Verify Districts package.order contains the models
+        with open(project_path / 'Districts' / 'package.order') as f:
+            content = f.read()
+            self.assertIn('Model1', content)
+            self.assertIn('Model2', content)
+
+    def test_subpackage_attribute_error(self):
+        """Test that accessing non-existent subpackage raises AttributeError"""
+        project_path = Path(self.output_dir) / 'test_error_project'
+        if project_path.exists():
+            import shutil
+            shutil.rmtree(project_path)
+        project_path.mkdir(parents=True)
+        
+        package = PackageParser.new_from_template(
+            project_path,
+            'ErrorProject',
+            [],
+            mbl_version='12.1.0'
+        )
+        
+        with self.assertRaises(AttributeError) as context:
+            _ = package.nonexistent
+        
+        self.assertIn('nonexistent', str(context.exception))
+
+    def test_case_insensitive_subpackage_access(self):
+        """Test that subpackage access is case-insensitive"""
+        project_path = Path(self.output_dir) / 'test_case_project'
+        if project_path.exists():
+            import shutil
+            shutil.rmtree(project_path)
+        project_path.mkdir(parents=True)
+        
+        package = PackageParser.new_from_template(
+            project_path,
+            'CaseProject',
+            [],
+            mbl_version='12.1.0'
+        )
+        
+        package.add_model('Districts')
+        
+        # All these should work
+        districts1 = package.districts
+        districts2 = package.Districts
+        districts3 = package.DISTRICTS
+        
+        self.assertIs(districts1, districts2)
+        self.assertIs(districts2, districts3)
+
+    def test_full_workflow(self):
+        """Test the complete workflow from the user's pseudo code"""
+        project_path = Path(self.output_dir) / 'test_workflow'
+        if project_path.exists():
+            import shutil
+            shutil.rmtree(project_path)
+        project_path.mkdir(parents=True)
+        
+        # User's desired pseudo code
+        package = PackageParser.new_from_template(
+            project_path,
+            'WorkflowProject',
+            [],
+            mbl_version='12.1.0'
+        )
+        package.add_model('Districts')
+        package.districts.add_model('junk')
+        package.save()
+        
+        # Verify the structure was created
+        self.assertTrue((project_path / 'package.mo').exists())
+        self.assertTrue((project_path / 'Districts').exists())
+        self.assertTrue((project_path / 'Districts' / 'junk').exists())
+        self.assertTrue((project_path / 'Districts' / 'junk' / 'package.mo').exists())
+        
+        # Verify package.order contents
+        with open(project_path / 'package.order') as f:
+            self.assertIn('Districts', f.read())
+        
+        with open(project_path / 'Districts' / 'package.order') as f:
+            self.assertIn('junk', f.read())
+        
+        # Verify within statements in package.mo files
+        with open(project_path / 'Districts' / 'package.mo') as f:
+            content = f.read()
+            self.assertIn('within WorkflowProject;', content)
+        
+        with open(project_path / 'Districts' / 'junk' / 'package.mo') as f:
+            content = f.read()
+            self.assertIn('within WorkflowProject.Districts;', content)

--- a/tests/test_package_parser.py
+++ b/tests/test_package_parser.py
@@ -246,13 +246,16 @@ class PackageParserTest(unittest.TestCase):
             mbl_version='12.1.0'
         )
 
-        package.add_model('Districts', create_subpackage=True)
+        # Capture the returned subpackage from add_model
+        returned_districts = package.add_model('Districts', create_subpackage=True)
 
         # All these should work
         districts1 = package.districts
         districts2 = package.Districts
         districts3 = package.DISTRICTS
 
+        # Verify that the returned subpackage is the same instance as accessed via attribute notation
+        self.assertIs(returned_districts, districts1)
         self.assertIs(districts1, districts2)
         self.assertIs(districts2, districts3)
 

--- a/tests/test_package_parser.py
+++ b/tests/test_package_parser.py
@@ -2,6 +2,7 @@
 # See also https://github.com/urbanopt/modelica-builder/blob/develop/LICENSE.md
 
 import os
+import shutil
 import unittest
 from pathlib import Path
 
@@ -317,3 +318,35 @@ class PackageParserTest(unittest.TestCase):
         # Verify that add_model works with create_subpackage=False
         package.add_model('NewModel', create_subpackage=False)
         self.assertIn('NewModel', package.order)
+
+    def test_subpackage_cache_synchronization(self):
+        """Test that add_model returns the same instance if subpackage is already cached"""
+        project_path = Path(self.output_dir) / 'test_cache_sync'
+        if project_path.exists():
+            shutil.rmtree(project_path)
+        project_path.mkdir(parents=True)
+
+        package = PackageParser.new_from_template(
+            project_path,
+            'CacheProject',
+            [],
+            mbl_version='12.1.0'
+        )
+
+        # First, create the subpackage using add_model
+        districts1 = package.add_model('Districts', create_subpackage=True)
+
+        # Try to call add_model again with the same name
+        districts2 = package.add_model('Districts', create_subpackage=True)
+
+        # Verify they are the same instance
+        self.assertIs(districts1, districts2, "add_model should return cached instance")
+
+        # Also verify attribute access returns the same instance
+        districts3 = package.districts
+        self.assertIs(districts1, districts3, "Attribute access should return cached instance")
+
+        # Verify that the model name only appears once in the order
+        order_lines = [line for line in package.order_data.split('\n') if line.strip()]
+        districts_count = sum(1 for line in order_lines if line == 'Districts')
+        self.assertEqual(districts_count, 1, "Model name should only appear once in order")

--- a/tests/test_package_parser.py
+++ b/tests/test_package_parser.py
@@ -299,3 +299,21 @@ class PackageParserTest(unittest.TestCase):
         with open(project_path / 'Districts' / 'Model_Sigma' / 'package.mo') as f:
             content = f.read()
             self.assertIn('within WorkflowProject.Districts;', content)
+
+    def test_add_model_with_no_path_raises_error(self):
+        """Test that add_model raises ValueError when create_subpackage=True but path is None"""
+        # Create a PackageParser without a path
+        package = PackageParser()
+        package.order_data = "model_a\nmodel_b"
+        package.package_name = "TestPackage"
+
+        # Try to add a model with create_subpackage=True
+        with self.assertRaises(ValueError) as context:
+            package.add_model('NewModel', create_subpackage=True)
+
+        self.assertIn("Cannot create subpackage 'NewModel'", str(context.exception))
+        self.assertIn("PackageParser.path is None", str(context.exception))
+
+        # Verify that add_model works with create_subpackage=False
+        package.add_model('NewModel', create_subpackage=False)
+        self.assertIn('NewModel', package.order)

--- a/tests/test_package_parser.py
+++ b/tests/test_package_parser.py
@@ -139,7 +139,7 @@ class PackageParserTest(unittest.TestCase):
         )
 
         # Add a subpackage
-        package.add_model('Districts')
+        package.add_model('Districts', create_subpackage=True)
         package.save()  # Save to write files to disk
 
         # Access via attribute notation
@@ -170,8 +170,8 @@ class PackageParserTest(unittest.TestCase):
         )
 
         # Add nested subpackages
-        package.add_model('Districts')
-        package.districts.add_model('Models')
+        package.add_model('Districts', create_subpackage=True)
+        package.districts.add_model('Models', create_subpackage=True)
         package.save()  # Save to write files to disk
 
         # Verify structure
@@ -198,7 +198,7 @@ class PackageParserTest(unittest.TestCase):
             mbl_version='12.1.0'
         )
 
-        package.add_model('Districts')
+        package.add_model('Districts', create_subpackage=True)
         package.districts.add_model('Model1', create_subpackage=False)
         package.districts.add_model('Model2', create_subpackage=False)
 
@@ -246,7 +246,7 @@ class PackageParserTest(unittest.TestCase):
             mbl_version='12.1.0'
         )
 
-        package.add_model('Districts')
+        package.add_model('Districts', create_subpackage=True)
 
         # All these should work
         districts1 = package.districts
@@ -271,8 +271,8 @@ class PackageParserTest(unittest.TestCase):
             [],
             mbl_version='12.1.0'
         )
-        package.add_model('Districts')
-        package.districts.add_model('Model_Sigma')
+        package.add_model('Districts', create_subpackage=True)
+        package.districts.add_model('Model_Sigma', create_subpackage=True)
         package.save()
 
         # Verify the structure was created


### PR DESCRIPTION
The package parser in the class was very simple and did not allow nested packages. This updates allows the following:

```python
  package = PackageParser.new_from_template(
      project_path,
      'WorkflowProject',
      [],
      mbl_version='12.1.0'
  )
  package.add_model('Districts')
  package.districts.add_model('Model_Sigma')
  package.districts.model_sigma.<methodmethodmethod>
  package.save()
```

And will create the package.mo and package.order files accordingly for each new subpackage.